### PR TITLE
use local nextTick reference, deleting Vue scope dependency

### DIFF
--- a/src/components/CalendarPane.vue
+++ b/src/components/CalendarPane.vue
@@ -144,7 +144,6 @@
 </template>
 
 <script>
-import Vue from 'vue';
 import CalendarWeeks from './CalendarWeeks';
 import CalendarNav from './CalendarNav';
 import Popover from './Popover';
@@ -391,7 +390,7 @@ export default {
     },
     preloadPages() {
       // Load the next and previous pages
-      Vue.nextTick(() => {
+      this.$nextTick(() => {
         this.loadPage(this.page_.prevMonthComps);
         this.loadPage(this.page_.nextMonthComps);
         this.pages = this.pages.filter(p => p.loaded);

--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -50,7 +50,6 @@
 </template>
 
 <script>
-import Vue from 'vue';
 import Popover from './Popover';
 import SingleDatePicker from './SingleDatePicker';
 import MultipleDatePicker from './MultipleDatePicker';
@@ -215,7 +214,7 @@ export default {
       this.updateInputValue();
     },
     updateInputValue() {
-      Vue.nextTick(() => { this.inputValue = this.profile.formatValue(this.value, this.dragValue); });
+      this.$nextTick(() => { this.inputValue = this.profile.formatValue(this.value, this.dragValue); });
     },
   },
 };

--- a/src/components/Popover.vue
+++ b/src/components/Popover.vue
@@ -42,7 +42,6 @@
 </template>
 
 <script>
-import Vue from 'vue';
 import defaults from '../utils/defaults';
 import { ancestorElements } from '../utils/helpers';
 import { POPOVER_VISIBILITIES as VISIBILITIES } from '../utils/constants';
@@ -174,7 +173,7 @@ export default {
       if (this.visibility === VISIBILITIES.FOCUS) {
         // Trap focus if element losing focus is nested within the popover content
         if (e.target !== this.$refs.popover && ancestorElements(e.target).includes(this.$refs.popoverContent)) {
-          Vue.nextTick(() => this.$refs.popover.focus());
+          this.$nextTick(() => this.$refs.popover.focus());
         }
         this.visibleManaged = false;
       }


### PR DESCRIPTION
Relating to issue #23 
[Doc says](https://vuejs.org/v2/api/#vm-nextTick) that `vm.$nextTick`:

>  This is the same as the global Vue.nextTick, except that the callback’s this context is automatically bound to the instance calling this method.

We don't have context change because arrow functions. So these changes should be safe.

Notice:
I have not enough experience in Vue and babel for ensure my changes, please check them before accept the pull request.