### PR TITLE
Zero out the hours using UTC so it doesn't change the date unexpectedly

### DIFF
--- a/src/utils/dateInfo.js
+++ b/src/utils/dateInfo.js
@@ -233,7 +233,7 @@ const DateInfo = (config, order) => {
     // Can't accept invalid dates
     if (isNaN(date)) return null;
     // Strip date time
-    date.setHours(0, 0, 0, 0);
+    date.setUTCHours(0, 0, 0, 0);
     // Assign date
     info.date = date;
     info.dateTime = date.getTime();


### PR DESCRIPTION
I'm concerned as to how this may affect other usages of locale specific
dates, but I think this is the correct way to go. This is meant to
handle dates which in almost every case I would assume should be
timezone agnostic and you just want a "date (TM)".

This should resolve #50. 