### PR TITLE
Added day content slot

### DIFF
--- a/docs/components/home/tables/TableCalendarSlots.vue
+++ b/docs/components/home/tables/TableCalendarSlots.vue
@@ -40,6 +40,11 @@ export default {
         props: '<code>page: Object</code>',
       },
       {
+        name: '<code>day-content</code>',
+        description: 'Calendar day content. Use this slot display custom day content.',
+        props: '<code>attributes: Array</code>, <code>day: Object</code>',
+      },
+      {
         name: '<code>day-popover-header</code>',
         description: 'If popover content is visible, this slot displays as the header.',
         props: '<code>attributes: Array</code>, <code>day-info: Object</code>',

--- a/docs/components/home/tables/TableCalendarSlots.vue
+++ b/docs/components/home/tables/TableCalendarSlots.vue
@@ -40,11 +40,6 @@ export default {
         props: '<code>page: Object</code>',
       },
       {
-        name: '<code>day-content</code>',
-        description: 'Calendar day content. Use this slot display custom day content.',
-        props: '<code>attributes: Array</code>, <code>day: Object</code>',
-      },
-      {
         name: '<code>day-popover-header</code>',
         description: 'If popover content is visible, this slot displays as the header.',
         props: '<code>attributes: Array</code>, <code>day-info: Object</code>',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2719,11 +2719,6 @@
         "assert-plus": "1.0.0"
       }
     },
-    "date-fns": {
-      "version": "2.0.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.0.0-alpha.7.tgz",
-      "integrity": "sha1-JFrRb5V2Tqur+ywKQf1dAzwg5Xo="
-    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",

--- a/src/components/CalendarDay.vue
+++ b/src/components/CalendarDay.vue
@@ -39,7 +39,11 @@
         @mouseenter='mouseenter'
         @mouseover='mouseover'
         @mouseleave='mouseleave'>
-        {{ label }}
+        <slot name='day-content' 
+          :day='day' 
+          :attributes='attributesList'>
+          {{ day.label }}
+        </slot>
       </div>
     </div>
     <!-- Dots layer -->


### PR DESCRIPTION
I need to display custom content for some days and I thought this will be nice feature for everyone who want need to display custom data with day or even some image instead of day.

Use Cases:
- Moon Calendar: Moon phases as image instead of day text
- Special days: You can put emoji for some special dates.
- Weather Calendar: Degree instead of days

Moon Calendar Example:
```
<v-calendar>
    <template :slot="day-content" slot-scope="props">
        <moon-phase :date="props.day.date" />
    </template>
</v-calendar>
```