### PR TITLE
Fix wrong weekdays name

### DIFF
--- a/docs/components/home/tables/TableCalendarSlots.vue
+++ b/docs/components/home/tables/TableCalendarSlots.vue
@@ -40,6 +40,11 @@ export default {
         props: '<code>page: Object</code>',
       },
       {
+        name: '<code>day-content</code>',
+        description: 'Calendar day content. Use this slot display custom day content.',
+        props: '<code>attributes: Array</code>, <code>day: Object</code>',
+      },
+      {
         name: '<code>day-popover-header</code>',
         description: 'If popover content is visible, this slot displays as the header.',
         props: '<code>attributes: Array</code>, <code>day-info: Object</code>',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2719,11 +2719,6 @@
         "assert-plus": "1.0.0"
       }
     },
-    "date-fns": {
-      "version": "2.0.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.0.0-alpha.7.tgz",
-      "integrity": "sha1-JFrRb5V2Tqur+ywKQf1dAzwg5Xo="
-    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",

--- a/src/components/CalendarDay.vue
+++ b/src/components/CalendarDay.vue
@@ -39,7 +39,11 @@
         @mouseenter='mouseenter'
         @mouseover='mouseover'
         @mouseleave='mouseleave'>
-        {{ label }}
+        <slot name='day-content' 
+          :day='day' 
+          :attributes='attributesList'>
+          {{ day.label }}
+        </slot>
       </div>
     </div>
     <!-- Dots layer -->

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -23,8 +23,8 @@ export const getMonthDates = (year = 2000) => {
 export const getWeekdayDates = (firstDayOfWeek = 1, year = 2000) => {
   const dates = [];
   for (let i = 1, j = 0; j < 7; i++) {
-    const d = new Date(year, 0, i);
-    if (d.getDay() === firstDayOfWeek - 1 || j > 0) {
+    const d = new Date(Date.UTC(year, 0, i));
+    if (d.getUTCDay() === firstDayOfWeek - 1 || j > 0) {
       dates.push(d);
       j++;
     }

--- a/src/utils/locales.js
+++ b/src/utils/locales.js
@@ -71,7 +71,7 @@ const locales = {
   // Thai
   th: { L: 'DD/MM/YYYY' },
   // Turkish
-  tk: { dow: 2, L: 'DD.MM.YYYY' },
+  tr: { dow: 2, L: 'DD.MM.YYYY' },
 };
 locales.en = locales['en-US'];
 locales.zh = locales['zh-CN'];


### PR DESCRIPTION
Fix for #104 

Intl library uses UTC time when formating the date so Date timezone should be in UTC too for correct formating. I also changed getDay to getUTCDay so sunday will always be first day of week.

I am not sure this will break other things.