### PR TITLE
Add Estonian locale

### DIFF
--- a/src/utils/locales.js
+++ b/src/utils/locales.js
@@ -74,6 +74,8 @@ const locales = {
   tr: { dow: 2, L: 'DD.MM.YYYY' },
   // Ukrainian
   uk: { dow: 2, L: 'DD.MM.YYYY' },
+  // Estonian
+  et: { dow: 2, L: 'DD.MM.YYYY' },
 };
 locales.en = locales['en-US'];
 locales.zh = locales['zh-CN'];


### PR DESCRIPTION
v-calendar is a lovely piece of code but it is missing at least one locale right now: Estonian. This pull request takes care of that. Thank you.