### PR TITLE
feat(locale): add es-MX locale

### DIFF
--- a/src/utils/locales.js
+++ b/src/utils/locales.js
@@ -66,6 +66,8 @@ const locales = {
   sk: { dow: 2, L: 'DD.MM.YYYY' },
   // Spanish
   es: { dow: 1, L: 'DD/MM/YYYY' },
+  // Spanish (MX)
+  'es-MX': { L: 'DD/MM/YYYY' },
   // Swedish
   sv: { dow: 2, L: 'YYYY-MM-DD' },
   // Thai


### PR DESCRIPTION
This PR adds support for `es-MX` _(Mexico)_ locale.

_The first day of the week in Mexico is Sunday, so `dow ` 1 is inferrred._