### PR TITLE
Corrected first day of month by creating it according to user's timezone

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "v-calendar",
-  "version": "0.9.7",
+  "name": "hostelworld-v-calendar",
+  "version": "0.9.8",
   "description": "A clean and extendable plugin for building simple attributed calendars in Vue.js.",
   "keywords": [
     "vue",

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -77,7 +77,8 @@ export const getMonthComps = (month, year) => {
   if (!comps) {
     const firstDayOfWeek = defaults.firstDayOfWeek;
     const inLeapYear = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
-    const firstWeekday = new Date(year, month - 1, 1).getDay() + 1;
+    const firstDay = new Date(Date.UTC(year, month - 1, 1));
+    const firstWeekday = new Date(firstDay.getTime() + firstDay.getTimezoneOffset() * 60000).getDay() + 1;
     const days = month === 2 && inLeapYear ? 29 : daysInMonths[month - 1];
     const weeks = Math.ceil(
       (days + Math.abs(firstWeekday - firstDayOfWeek)) / 7,


### PR DESCRIPTION
When calculating the months configuration variables if the first day of the month is not based on the user timezone the dates in the calendar pane will shift 1 day in the past depending on the browser timezone.