### PR TITLE
Use em instead of rem in styles

### DIFF
--- a/src/styles/vars.sass
+++ b/src/styles/vars.sass
@@ -20,11 +20,11 @@ $weight-medium: 500 !default
 $weight-semibold: 600 !default
 $weight-bold: 700 !default
 
-$size-3: 1.15rem
-$size-4: 1.1rem
-$size-5: 1rem
-$size-6: 0.9rem !default
-$size-7: 0.8rem !default
+$size-3: 1.15em
+$size-4: 1.1em
+$size-5: 1em
+$size-6: 0.9em !default
+$size-7: 0.8em !default
 
 $radius-rounded: 290486px !default
 
@@ -48,7 +48,7 @@ $nav-title-font-weight: $weight-medium
 $nav-table-font-size: $size-6
 $nav-table-font-weight: $weight-normal
 
-$arrow-font-size: 1.6rem
+$arrow-font-size: 1.6em
 $arrow-transition: fill-opacity .3s ease-in-out
 
 $weekday-color: $grey
@@ -61,8 +61,8 @@ $weeks-translate-x: 20px
 $weeks-transition: all .25s ease-in-out
 
 $day-min-height: 28px
-$day-content-width: 1.8rem
-$day-content-height: 1.8rem
+$day-content-width: 1.8em
+$day-content-height: 1.8em
 $day-content-font-size: $size-6
 $day-content-font-weight: $weight-normal
 $day-content-border-radius: 50%


### PR DESCRIPTION
Components should use em instead of rem, so that the size is relative.

Small hacked example: https://codepen.io/anon/pen/Jmxyaj