### PR TITLE
Add test for Grid component

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@vue/cli-plugin-unit-jest": "^3.4.0",
     "@vue/cli-service": "^3.4.0",
     "@vue/eslint-config-airbnb": "^4.0.0",
-    "@vue/test-utils": "^1.0.0-beta.28",
+    "@vue/test-utils": "1.0.0-beta.29",
     "babel-core": "^7.0.0-0",
     "babel-jest": "^22.0.4",
     "postcss-preset-env": "^6.6.0",

--- a/tests/unit/specs/Grid.spec.js
+++ b/tests/unit/specs/Grid.spec.js
@@ -1,0 +1,54 @@
+import { shallowMount } from '@vue/test-utils';
+import Grid from '@/components/Grid';
+
+describe('Grid', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallowMount(Grid);
+  });
+
+  describe(':props', () => {
+    it(':rows - renders specified number of rows', () => {
+      wrapper.setProps({ rows: 3 });
+
+      expect(wrapper.findAll('.vc-grid-cell').length).toBe(3);
+
+      expect(wrapper.find('.vc-grid-cell-row-1').exists()).toBe(true);
+      expect(wrapper.find('.vc-grid-cell-row-2').exists()).toBe(true);
+      expect(wrapper.find('.vc-grid-cell-row-3').exists()).toBe(true);
+
+      expect(wrapper.findAll('.vc-grid-cell-col-1').length).toBe(3);
+    });
+
+    it(':columns - renders specified number of columns', () => {
+      wrapper.setProps({ columns: 3 });
+
+      expect(wrapper.findAll('.vc-grid-cell').length).toBe(3);
+
+      expect(wrapper.find('.vc-grid-cell-col-1').exists()).toBe(true);
+      expect(wrapper.find('.vc-grid-cell-col-2').exists()).toBe(true);
+      expect(wrapper.find('.vc-grid-cell-col-3').exists()).toBe(true);
+
+      expect(wrapper.findAll('.vc-grid-cell-row-1').length).toBe(3);
+    });
+
+    it(':autofit - if true, sets auto-fit', () => {
+      wrapper.setProps({ autofit: true });
+
+      expect(wrapper.html()).toContain('repeat(auto-fit, 1fr)');
+    });
+
+    it(':autofit - if false, repeats number of columns', () => {
+      wrapper.setProps({ columns: 2, autofit: false });
+
+      expect(wrapper.html()).toContain('repeat(2, 1fr)');
+    });
+
+    it(':columnWidth - sets column width', () => {
+      wrapper.setProps({ columnWidth: '2fr' });
+
+      expect(wrapper.html()).toContain('repeat(1, 2fr)');
+    });
+  });
+});


### PR DESCRIPTION
Hey @nathanreyes 👋🏻

As I've been starting to use `v-calendar` more and more, I've noticed the lack of tests on the project, which is a bit concerning. I've raised it in #338, but then thought I might try and actually contribute, to begin with.

There is a lot of logic in the library, so it was very challenging to understand the flow of data and specifically what object props contain. Especially on < 1.0 version, so I decided to look at `next` branch instead. I'd like to do more tests, but I started with the first simple one I found, which was the `Grid` component.

## Description

This PR just adds some simple tests for the `Grid` component, without doing anything too involved. I've outlined possible improvements in light of it, but I thought this is a good start. I also use namespacing, that is based on [this talk](https://www.youtube.com/watch?v=OIpfWTThrK8), which you are free to adopt or I can change them to follow your personal preference. 

I've also bumped the version of vue test utils, while I am at it.

Here is a snapshot of test coverage increase, which as mentioned, only raises scoped slot logic not being tested :

| Before  | After |
| ------------- | ------------- |
| <img width="587" alt="Screen Shot 2019-06-28 at 17 33 39" src="https://user-images.githubusercontent.com/4270980/60357226-fe46b100-99ca-11e9-8f85-a693d9c809f0.png"> | <img width="559" alt="Screen Shot 2019-06-28 at 17 32 56" src="https://user-images.githubusercontent.com/4270980/60357261-161e3500-99cb-11e9-8535-44743e6b4918.png"> |

## Possible improvements
- I've noticed `count` prop is not used anywhere, so there was nothing to test. I am not sure if you got something in mind for it, but if not, perhaps it could be deleted?
- I avoided the use of Jest snapshots, as those have both pros and cons. But as this component specifically renders some markup, a snapshot might be a good idea
- I didn't test the `slot` functionality, so that's something that should be added, but I thought, for now, it could be left aside.