### PR TITLE
(doc) removing css import from the Plugin Method installation (it doesn't exists anymore)

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,6 @@ This is the most common use case.
 ```javascript
 import Vue from 'vue';
 import VCalendar from 'v-calendar';
-import 'v-calendar/lib/v-calendar.min.css';
 
 // Use v-calendar, v-date-picker & v-popover components
 Vue.use(VCalendar, {


### PR DESCRIPTION
It seems like the 'v-calendar.min.css' from the 'v-calendar/lib/v-calendar.min.css' doesn't exist anymore, so I'm removing it from the documentation