### PR TITLE
fix(build): makes sure arrow functions are not left in transpiled modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,9 @@
     "vue": "^2.5.18"
   },
   "browserslist": [
-    ">1%",
+    "> 0.5%",
+    "last 2 versions",
+    "Firefox ESR",
     "not ie 11",
     "not op_mini all"
   ]


### PR DESCRIPTION
The current `browserslist` configuration left arrow functions in transpiled modules. This break the behaviour of some versions of UglifyJS that are still in use.

This resolves #385.