### PR TITLE
Change elementHasAncestor to use Element.prototype.closest

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,11 +489,11 @@ export default {
 
 ### Polyfill
 
-`v-calendar` is transpiled for ES5, but it still needs a polyfill for `Array.prototype.find` (<= IE11) or even `Intl` (Javascript's internationalization object, <= IE10) if you wish to target older browsers. Two options for accomplishing this are:
+`v-calendar` is transpiled for ES5, but it still needs a polyfill for `Array.prototype.find` and `Element.closest` (<= IE11) or even `Intl` (Javascript's internationalization object, <= IE10) if you wish to target older browsers. Two options for accomplishing this are:
 1. **Easy way:**
   Insert the following script into your html before loading `v-calendar`. The polyfill will get loaded automatically *only if* the browser needs it.
 
-  `<script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=Array.prototype.find,Intl" />`
+  `<script src="https://polyfill.io/v3/polyfill.min.js?features=Array.prototype.find%2CElement.prototype.closest%2CIntl" />`
 
 2. In Node/Browserify/Webpack environments, use [babel-polyfill](https://babeljs.io/docs/usage/polyfill/) to insert the polyfill for you.
 

--- a/src/components/Popover.vue
+++ b/src/components/Popover.vue
@@ -148,7 +148,7 @@ export default {
     },
     focusout(e) {
       // Hide when outside element (e.relatedTarget) receives focus
-      if (!elementHasAncestor(e.relatedTarget, this.$refs.popover)) {
+      if (!elementHasAncestor(e.relatedTarget, '.popover-container')) {
         this.$emit('lost-focus', e);
         this.focusVisible = false;
       }
@@ -159,8 +159,8 @@ export default {
       if (
         this.toggleVisibleOnClick &&
         !this.contentTransitioning &&
-        elementHasAncestor(e.target, this.$refs.popover) &&
-        !elementHasAncestor(e.target, this.$refs.popoverOrigin) &&
+        elementHasAncestor(e.target, '.popover-container') &&
+        !elementHasAncestor(e.target, '.popover-origin') &&
         !this.disableNextClick
       ) {
         this.focusVisible = !this.focusVisible;
@@ -176,13 +176,13 @@ export default {
     mouseleave(e) {
       if (
         !this.forceHidden &&
-        !elementHasAncestor(e.relatedTarget, this.$refs.popover)
+        !elementHasAncestor(e.relatedTarget, '.popover-container')
       ) {
         this.hoverVisible = false;
       }
     },
     windowTapOrClick(e) {
-      if (!elementHasAncestor(e.target, this.$refs.popover)) {
+      if (!elementHasAncestor(e.target, '.popover-container')) {
         this.hoverVisible = false;
         this.focusVisible = false;
       }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -210,14 +210,8 @@ export const getLastArrayItem = (array, fallbackValue) => {
 
 export const arrayHasItems = array => isArray(array) && array.length;
 
-export const findAncestor = (el, fn) => {
-  if (!el) return null;
-  if (fn(el)) return el;
-  return findAncestor(el.parentElement, fn);
-};
-
-export const elementHasAncestor = (el, ancestor) =>
-  !!findAncestor(el, e => e === ancestor);
+export const elementHasAncestor = (el, ancestorSelector) =>
+  el && !!el.closest(ancestorSelector);
 
 export const elementPositionInAncestor = (el, ancestor) => {
   let top = 0;


### PR DESCRIPTION
Fixes a bug in IE11 where FocusEvent.relatedTarget is sometimes null for SVG elements.

Bug only happened in IE11. The buggy behavior happened when opening a DatePicker set to `visibility: focus`, clicking on the arrows to change the month would close the Popover.

It should be noted that `Element.prototype.closest` requires a polyfill for IE11.