### PR TITLE
fix Incorrect event name

### DIFF
--- a/docs/api/calendar.md
+++ b/docs/api/calendar.md
@@ -242,13 +242,13 @@ The `.sync` modifier does not work with this prop, unlike `to-page`.
 
 ## Events
 
-### `update:frompage`
+### `update:from-page`
 
 **Description:** Calendar left/single pane moved to a different page.
 
 **Params:** [`page`](./page-object.md)
 
-### `update:topage`
+### `update:to-page`
 
 **Description:** Calendar right pane moved to a different page.
 


### PR DESCRIPTION
v1.0.1

```@update:frompage``` is not work.
```@update:from-page``` is work.


---

[This Issue](https://github.com/nathanreyes/v-calendar/issues/186)  is also incrrect(```@update:fromPage``` is not work on v1.0.1), so it might be better to reopen and fix.