### PR TITLE
Fix range text input when using a date format containing dashes

### DIFF
--- a/src/utils/pickers/range.js
+++ b/src/utils/pickers/range.js
@@ -43,7 +43,7 @@ export default class RangePicker {
   parse(text) {
     let start;
     let end;
-    const dateTexts = text.split('-').map(s => s.trim());
+    const dateTexts = text.split(' - ').map(s => s.trim());
     if (dateTexts.length >= 2) {
       start = this._parse(dateTexts[0]);
       end = this._parse(dateTexts[1]);


### PR DESCRIPTION
When using a date format containing dashes in a range date-picker. The parsing of the text input is not valid.

Fixes #272