### PR TITLE
Fix Dutch date notation.

### DIFF
--- a/src/utils/defaults/locales.js
+++ b/src/utils/defaults/locales.js
@@ -18,7 +18,7 @@ const locales = {
   // Danish
   da: { dow: 2, L: 'DD.MM.YYYY' },
   // Dutch
-  nl: { dow: 2, L: 'DD.MM.YYYY' },
+  nl: { dow: 2, L: 'DD-MM-YYYY' },
   // English (US)
   'en-US': { dow: 1, L: 'MM/DD/YYYY' },
   // English (Australia)


### PR DESCRIPTION
Dutch date notation should be separated with dashes instead of dots.
https://en.wikipedia.org/wiki/Date_and_time_notation_in_the_Netherlands