### PR TITLE
Allow custom options when using CDN installation

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -796,7 +796,15 @@ setupCalendar({
     <!-- 1. Link Vue Javascript -->
     <script src='https://unpkg.com/vue/dist/vue.js'></script>
 
-    <!-- 2. Link VCalendar Javascript (Plugin automatically installed) -->
+    <!-- 2. Set default options -->
+    <script type="javascript">
+        window.VCalendarOptions = {
+            componentPrefix: 'vc',
+            ...,
+        }
+    </script>
+
+    <!-- 3. Link VCalendar Javascript (Plugin automatically installed) -->
     <!-- @next v1 Beta  -->
     <script src='https://unpkg.com/v-calendar@next'></script>
     <!-- Latest stable (Right now, this is very different from the v1 Beta)-->
@@ -804,7 +812,7 @@ setupCalendar({
     <!-- Hardcoded version -->
     <!-- <script src='https://unpkg.com/v-calendar@1.0.0-beta.14/lib/v-calendar.umd.min.js'></script> -->
 
-    <!--3. Create the Vue instance-->
+    <!-- 4. Create the Vue instance-->
     <script>
       new Vue({
         el: '#app',

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -85,10 +85,18 @@ setupCalendar({
     <!-- 1. Link Vue Javascript -->
     <script src='https://unpkg.com/vue/dist/vue.js'></script>
 
-    <!-- 2. Link VCalendar Javascript (Plugin automatically installed) -->
+    <!-- 2. Set default options -->
+    <script type="javascript">
+        window.VCalendarOptions = {
+            componentPrefix: 'vc',
+            ...,
+        }
+    </script>
+
+    <!-- 3. Link VCalendar Javascript (Plugin automatically installed) -->
     <script src='https://unpkg.com/v-calendar'></script>
 
-    <!--3. Create the Vue instance-->
+    <!-- 4. Create the Vue instance-->
     <script>
       new Vue({
         el: '#app',

--- a/src/lib.js
+++ b/src/lib.js
@@ -47,13 +47,17 @@ const plugin = {
 
 // Use automatically when global Vue instance detected
 let GlobalVue = null;
+let GlobalOptions = null;
+
 if (typeof window !== 'undefined') {
   GlobalVue = window.Vue;
+  GlobalOptions = window.VCalendarOptions;
 } else if (typeof global !== 'undefined') {
   GlobalVue = global.Vue;
+  GlobalOptions = global.VCalendarOptions;
 }
 if (GlobalVue) {
-  GlobalVue.use(plugin);
+  GlobalVue.use(plugin, GlobalOptions);
 }
 
 // Export components/helpers individually


### PR DESCRIPTION
Hi there!

This change simply allow anyone using CDN installation to initialize the plugin using global variable:
`window.VCalendarOptions`

For example:
`<script type="javascript">
        window.VCalendarOptions = {
            componentPrefix: 'vc'
       }
</script>`
`<script src='https://unpkg.com/v-calendar'></script>`