### PR TITLE
Corrected error in final scoped slot example

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -610,7 +610,7 @@ Finally, if you wish to display indicators with your custom content, you can use
       v-for="attr in attributes"
       :key="attr.key"
       :attribute="attr">
-      {{ customData.description }}
+      {{ attr.customData.description }}
     </popover-row>
   </div>
 </v-calendar>


### PR DESCRIPTION
The reference to customData.description should be attr.customData.description, example does not work.