### PR TITLE
Add Estonian, Latvian, Lithuanian locales

### DIFF
--- a/src/utils/defaults/locales.js
+++ b/src/utils/defaults/locales.js
@@ -33,6 +33,8 @@ const locales = {
   'en-NZ': { dow: 2, L: 'DD/MM/YYYY' },
   // Esperanto
   eo: { dow: 2, L: 'YYYY-MM-DD' },
+  // Estonian
+  et: { dow: 2, L: 'DD.MM.YYYY' },
   // Finnish
   fi: { dow: 2, L: 'DD.MM.YYYY' },
   // French
@@ -53,6 +55,10 @@ const locales = {
   ja: { dow: 1, L: 'YYYY年M月D日' },
   // Korean
   ko: { dow: 1, L: 'YYYY.MM.DD' },
+  // Latvian
+  lv: { dow: 2, L: 'DD.MM.YYYY' },
+  // Lithuanian
+  lt: { dow: 2, L: 'DD.MM.YYYY' },
   // Macedonian
   mk: { dow: 2, L: 'D.MM.YYYY' },
   // Norwegian


### PR DESCRIPTION
This PR adds locales for Estonian, Latvian and Lithuanian languages.