### PR TITLE
Screenreader friendly date picking

### DIFF
--- a/src/components/CalendarDay.vue
+++ b/src/components/CalendarDay.vue
@@ -211,6 +211,8 @@ export default {
       return {
         tabindex,
         'aria-label': this.day.ariaLabel,
+        'aria-disabled': this.day.isDisabled ? 'true' : 'false',
+        'role': 'button'
       };
     },
     dayContentEvents() {


### PR DESCRIPTION
When role=button and aria-disabled are set, a screenreader will say if the currently focused day is disabled. 