### PR TITLE
Vue 3 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "peerDependencies": {
     "@popperjs/core": "^2.4.0",
-    "vue": "^2.5.18"
+    "vue": "^3.0.0"
   },
   "browserslist": [
     ">1%",

--- a/src/lib.js
+++ b/src/lib.js
@@ -1,38 +1,27 @@
 import * as components from './components';
 import * as utils from './utils';
 
-// Declare install function executed by Vue.use()
-function install(Vue, opts) {
+// Declare install function executed by app.use()
+function install(app, opts) {
   // Don't install more than once
   if (install.installed) return;
   install.installed = true;
   // Manually setup calendar with options
-  const defaults = utils.setupCalendar(opts);
+  const defaults = utils.setupCalendar(app, opts);
   // Register components
   Object.entries(components).forEach(([componentName, component]) => {
-    Vue.component(`${defaults.componentPrefix}${componentName}`, component);
+    app.component(`${defaults.componentPrefix}${componentName}`, component);
   });
 }
 
-// Create module definition for Vue.use()
+// Create module definition for app.use()
 const plugin = {
   install,
   ...components,
   ...utils,
 };
 
-// Use automatically when global Vue instance detected
-let GlobalVue = null;
-if (typeof window !== 'undefined') {
-  GlobalVue = window.Vue;
-} else if (typeof global !== 'undefined') {
-  GlobalVue = global.Vue;
-}
-if (GlobalVue) {
-  GlobalVue.use(plugin);
-}
-
-// Default export is library as a whole, registered via Vue.use()
+// Default export is library as a whole, registered via app.use()
 export default plugin;
 
 // Allow component use individually

--- a/src/utils/defaults/index.js
+++ b/src/utils/defaults/index.js
@@ -32,7 +32,7 @@ let defaults_ = null;
 
 export const setupDefaults = opts => {
   if (!defaults_) {
-    defaults_ = new Vue({
+    defaults_ = Vue.createApp({
       data() {
         return {
           defaults: defaultsDeep(opts, pluginDefaults),

--- a/src/utils/screens.js
+++ b/src/utils/screens.js
@@ -16,7 +16,7 @@ export function setupScreens(screens = defaultScreens, forceSetup) {
   isSettingUp = true;
   shouldRefreshQueries = true;
   // Use a private Vue component to store reactive screen matches
-  screensComp = new Vue({
+  screensComp = Vue.createApp({
     data() {
       return {
         matches: [],
@@ -42,27 +42,29 @@ export function setupScreens(screens = defaultScreens, forceSetup) {
   isSettingUp = false;
 }
 
-// Global mixin that provides responsive '$screens' utility method
-// that refreshes any time the screen matches update
-Vue.mixin({
-  beforeCreate() {
-    if (!isSettingUp) {
-      setupScreens();
-    }
-  },
-  mounted() {
-    if (shouldRefreshQueries && screensComp) {
-      screensComp.refreshQueries();
-      shouldRefreshQueries = false;
-    }
-  },
-  computed: {
-    $screens() {
-      return (config, def) =>
-        screensComp.matches.reduce(
-          (prev, curr) => (has(config, curr) ? config[curr] : prev),
-          isUndefined(def) ? config.default : def,
-        );
+export function addMixin(app) {
+  // Global mixin that provides responsive '$screens' utility method
+  // that refreshes any time the screen matches update
+  app.mixin({
+    beforeCreate() {
+      if (!isSettingUp) {
+        setupScreens();
+      }
     },
-  },
-});
+    mounted() {
+      if (shouldRefreshQueries && screensComp) {
+        screensComp.refreshQueries();
+        shouldRefreshQueries = false;
+      }
+    },
+    computed: {
+      $screens() {
+        return (config, def) =>
+          screensComp.matches.reduce(
+            (prev, curr) => (has(config, curr) ? config[curr] : prev),
+            isUndefined(def) ? config.default : def,
+          );
+      },
+    },
+  });
+}

--- a/src/utils/setup.js
+++ b/src/utils/setup.js
@@ -1,10 +1,14 @@
 import { setupDefaults } from './defaults';
-import { setupScreens } from './screens';
+import { setupScreens, addMixin } from './screens';
 
-export default opts => {
+export default (app, opts) => {
   // Register plugin defaults
   const defaults = setupDefaults(opts);
+
+  addMixin(app);
+
   // Install support for responsive screens
   setupScreens(defaults.screens, true);
+
   return defaults;
 };


### PR DESCRIPTION
Hey! Eager to start using this project with Vue 3, so I fixed some of the errors that occurred when you tried using the plugin with Vue 3. The main thing is around the deprecation of the global `Vue` type for adding mixins and creating apps.

I haven't got a lot of experience with writing plugins, so there is probably a better way to write these changes in an architecture fitting the one already used in this repository. So please feel free to do your own version!

I haven't done any extensive testing yet. Also, not sure how to support using this plugin with a standard CDN, since we can't have the plugin bind to the global window instance anymore: [https://v3.vuejs.org/guide/migration/global-api.html#a-note-for-plugin-authors](url) so we need someway to do `app.use(VCalendar)` inside the script tag.
