### PR TITLE
AM PM Buttons reloading page

### DIFF
--- a/src/components/TimePicker.vue
+++ b/src/components/TimePicker.vue
@@ -36,10 +36,10 @@
         <span style="margin: 0 4px;">:</span>
         <time-select v-model.number="minutes" :options="minuteOptions" />
         <div v-if="!is24hr" class="vc-am-pm">
-          <button :class="{ active: isAM }" @click="isAM = true">
+          <button :class="{ active: isAM }" @click.prevent="isAM = true">
             AM
           </button>
-          <button :class="{ active: !isAM }" @click="isAM = false">
+          <button :class="{ active: !isAM }" @click.prevent="isAM = false">
             PM
           </button>
         </div>


### PR DESCRIPTION
Added a prevent default to the TimePicker component to stop pages being reloaded when trying to switch between AM - PM