### PR TITLE
AM & PM buttons were submitting form if placed inside <form> element

### DIFF
--- a/src/components/TimePicker.vue
+++ b/src/components/TimePicker.vue
@@ -36,10 +36,10 @@
         <span style="margin: 0 4px;">:</span>
         <time-select v-model.number="minutes" :options="minuteOptions" />
         <div v-if="!is24hr" class="vc-am-pm">
-          <button :class="{ active: isAM }" @click.prevent="isAM = true">
+          <button :class="{ active: isAM }" type="button" @click.prevent="isAM = true">
             AM
           </button>
-          <button :class="{ active: !isAM }" @click.prevent="isAM = false">
+          <button :class="{ active: !isAM }" type="button" @click.prevent="isAM = false">
             PM
           </button>
         </div>


### PR DESCRIPTION
I've just run into an issue where I placed the Date & Time picker inside a `<form>` element. When I clicked on the AM or PM buttons in the time picker, it would cause the form to be submitted.

This pull request adds the `type` attribute to the AM & PM buttons, and sets them to `button` which means they won't trigger a form submit.

I've included a test case below, its a stripped down, really simple version of what I'm using in my project.

```vue
<form action="#" method="post" @submit.prevent="submit">
  <v-date-picker v-model="date" mode="dateTime" timezone="GMT" />

  <button>Submit Form</button>
</form>
```

A workaround for me would be to use a `<div>` element instead of a form and add a `@submit` attribute to my submit button, which isn't ideal but it would work.

Hopefully it's helpful, let me know if you have any questions!