### PR TITLE
Added type attribute to time picker buttons

### DIFF
--- a/src/components/TimePicker.vue
+++ b/src/components/TimePicker.vue
@@ -36,10 +36,10 @@
         <span style="margin: 0 4px;">:</span>
         <time-select v-model.number="minutes" :options="minuteOptions" />
         <div v-if="!is24hr" class="vc-am-pm">
-          <button :class="{ active: isAM }" @click.prevent="isAM = true">
+          <button :class="{ active: isAM }" @click.prevent="isAM = true" type="button">
             AM
           </button>
-          <button :class="{ active: !isAM }" @click.prevent="isAM = false">
+          <button :class="{ active: !isAM }" @click.prevent="isAM = false" type="button">
             PM
           </button>
         </div>


### PR DESCRIPTION
Just added `type="button"` attributes to the time picker component so that a click on those buttons when the picker is part of a form won't trigger the form to submit.

Thanks for making this library @nathanreyes!