### PR TITLE
Fix iOS MediaQueryList unsupported API throwing exceptions

### DIFF
--- a/src/utils/screens.js
+++ b/src/utils/screens.js
@@ -3,7 +3,7 @@
 import Vue from 'vue';
 import buildMediaQuery from './buildMediaQuery';
 import defaultScreens from './defaults/screens.json';
-import { isUndefined, mapValues, toPairs, has } from './_';
+import { isUndefined, mapValues, toPairs, isFunction, has } from './_';
 
 let isSettingUp = false;
 let shouldRefreshQueries = false;
@@ -28,7 +28,12 @@ export function setupScreens(screens = defaultScreens, forceSetup) {
         if (!window || !window.matchMedia) return;
         this.queries = mapValues(screens, v => {
           const query = window.matchMedia(buildMediaQuery(v));
-          query.addEventListener('change', this.refreshMatches);
+          if (isFunction(query.addEventListener)) {
+            query.addEventListener('change', this.refreshMatches);
+          } else {
+            // Deprecated 'MediaQueryList' API, <Safari 14, <Edge 16
+            query.addListener(this.refreshMatches);
+          }
           return query;
         });
         this.refreshMatches();


### PR DESCRIPTION
This PR provides a fix for exceptions being thrown on iOS devices with Safari <14 due to missing `addEventListener` method on MediaQueryList object.  
[According to MDN](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener) addListener method should be used instead.

The issue can be reproduced by visiting https://vcalendar.io from iOS devices with Safar version <14. Visiting the page produces 90+ exceptions in devtools. See [Screenshot](https://i.imgur.com/25oU73F.png).

```
TypeError: t.addEventListener is not a function. (In 't.addEventListener("change",this.refreshMatches)', 't.addEventListener' is undefined)
```