### PR TITLE
Date picker improvements

### DIFF
--- a/docs/.vuepress/components/github/999.vue
+++ b/docs/.vuepress/components/github/999.vue
@@ -88,6 +88,7 @@
           :popover="popover"
           :is-dark="dark"
           :disabled-dates="disabledDates"
+          :is-required="isRequired"
         >
           <template v-slot="{ inputValue, inputEvents }" v-if="!inline">
             <div class="flex items-center">
@@ -113,6 +114,7 @@
           :popover="popover"
           :is-dark="dark"
           :disabled-dates="disabledDates"
+          :is-required="isRequired"
           is-range
         >
           <template v-slot="{ inputValue, inputEvents }" v-if="!inline">
@@ -176,9 +178,10 @@ export default {
       minuteIncrement: 1,
       inline: false,
       dark: false,
-      utc: true,
+      utc: false,
+      isRequired: true,
       popover: {
-        visibility: 'hover',
+        visibility: 'hover-focus',
         transition: 'slide-fade',
       },
     };

--- a/docs/.vuepress/components/github/999.vue
+++ b/docs/.vuepress/components/github/999.vue
@@ -179,7 +179,7 @@ export default {
       inline: false,
       dark: false,
       utc: false,
-      isRequired: true,
+      isRequired: false,
       popover: {
         visibility: 'hover-focus',
         transition: 'slide-fade',

--- a/docs/.vuepress/components/guide/datepicker/is-required.vue
+++ b/docs/.vuepress/components/guide/datepicker/is-required.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class="example">
+    <v-date-picker v-model="date" is-required>
+      <template v-slot="{ inputValue, inputEvents }">
+        <input
+          class="bg-white border px-2 py-1 rounded"
+          :value="inputValue"
+          v-on="inputEvents"
+        />
+      </template>
+    </v-date-picker>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      date: new Date(),
+    };
+  },
+};
+</script>

--- a/docs/.vuepress/components/guide/datepicker/model-string.vue
+++ b/docs/.vuepress/components/guide/datepicker/model-string.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="example">
     <div class="flex">
-      <v-date-picker v-model="customer.birthday" :model-config="modelConfig" />
+      <v-date-picker
+        v-model="customer.birthday"
+        :model-config="modelConfig"
+        is-required
+      />
       <div class="ml-4 text-sm">
         <h4 class="text-gray-700">Customer Info</h4>
         <div class="flex">

--- a/docs/.vuepress/components/guide/datepicker/with-value.vue
+++ b/docs/.vuepress/components/guide/datepicker/with-value.vue
@@ -52,7 +52,7 @@
         <span class="text-gray-600 font-semibold tracking-wide"
           >Date (ISO):</span
         >
-        <span class="text-gray-800 ml-2">{{ date.toISOString() }}</span>
+        <span class="text-gray-800 ml-2">{{ date && date.toISOString() }}</span>
       </div>
     </template>
     <template v-else>

--- a/docs/datepicker.md
+++ b/docs/datepicker.md
@@ -620,17 +620,31 @@ Refer to the [disabling dates section](./dates.md#disabling-dates).
 
 ## Require Selected Date
 
-There are 3 ways to clear a selected date (`value = null`).
+Setting the `is-required` prop will prevent clearing the date value by deleting all text from the `input` element or re-selecting a picker date.
 
-1. Assign `null` to `value` prop or to local state variable that is bound to using `v-model`
-2. User toggles selected dates by clicking them on the calendar (only valid when `mode` is `"single"` or `"multiple"`)
-3. User clears the input element text and commits the change by pressing the `enter` key or changing focus (`blur` event)
+<guide-datepicker-is-required />
 
-You can prevent methods 2 and 3 by setting the `is-required` prop to `true`.
+```html
+<v-date-picker v-model="date" is-required>
+  <template v-slot="{ inputValue, inputEvents }">
+    <input
+      class="bg-white border px-2 py-1 rounded"
+      :value="inputValue"
+      v-on="inputEvents"
+    />
+  </template>
+</v-date-picker>
+```
 
-::: warning
-This effectively prevents the _user_ from clearing the value. The developer can still clear it via method 1.
-:::
+```js
+export default {
+  data() {
+    return {
+      date: new Date(),
+    };
+  },
+};
+```
 
 ## Customize Attributes
 

--- a/docs/datepicker.md
+++ b/docs/datepicker.md
@@ -201,7 +201,11 @@ To bind to a string value, provide a `model-config` with the necessary `type: 's
 <guide-datepicker-model-string />
 
 ```html
-<v-date-picker v-model="customer.birthday" :model-config="modelConfig" />
+<v-date-picker
+  v-model="customer.birthday"
+  :model-config="modelConfig"
+  is-required
+  />
 ```
 
 ```js

--- a/docs/timezones.md
+++ b/docs/timezones.md
@@ -216,6 +216,30 @@ export default {
 
 ### Time Assignment
 
-Similarly, if `mode === 'date'` and the `modelConfig.timeAssign` has been explicitly set, then the assigned time will use the locally assigned `timezone` if one has been set, or the local browser's timezone otherwise.
+Similarly, if `mode === 'date'` and the `modelConfig.timeAssign` has been explicitly set, then the assigned time will reflect the assigned `timezone` or the local browser's timezone otherwise.
 
 <guide-timezones-picker-date />
+
+```html
+<v-date-picker
+  v-model="dateRange"
+  :model-config="modelConfig"
+  is-range
+/>
+```
+
+```js
+export default {
+  data() {
+    return {
+      dateRange: {
+        start: new Date(2020, 0, 6),
+        end: new Date(2020, 0, 10),
+      },
+      modelConfig: {
+        timeAdjust: '12:00:00',
+      },
+    };
+  },
+};
+```

--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -501,23 +501,19 @@ export default {
       };
     },
     onInputChange(config, isStart) {
-      const opts = {
-        config,
-        formatInput: true,
-        hidePopover: false,
-      };
       return e => {
         const inputValue = e.target.value;
-        if (this.isRange) {
-          this.inputValues.splice(isStart ? 0 : 1, 1, inputValue);
-          this.updateValue(
-            { start: this.inputValues[0], end: this.inputValues[1] },
-            opts,
-          );
-        } else {
-          this.inputValues.splice(0, 1, inputValue);
-          this.updateValue(inputValue, opts);
-        }
+        this.inputValues.splice(isStart ? 0 : 1, 1, inputValue);
+        const value = this.isRange
+          ? { start: this.inputValues[0], end: this.inputValues[1] }
+          : inputValue;
+        this.updateValue(value, {
+          config,
+          formatInput: true,
+          hidePopover: false,
+        }).then(() => {
+          this.adjustPageRange(isStart);
+        });
       };
     },
     onInputShow(isStart) {

--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -727,7 +727,7 @@ export default {
       });
     },
     hidePopover(opts = {}) {
-      hp({ ...opts, id: this.datePickerPopoverId });
+      hp({ hideDelay: 10, ...opts, id: this.datePickerPopoverId });
     },
     togglePopover(opts) {
       tp({

--- a/src/components/TimePicker.vue
+++ b/src/components/TimePicker.vue
@@ -204,6 +204,7 @@ export default {
           hours,
           minutes: this.minutes,
           seconds: 0,
+          milliseconds: 0,
         });
       });
     },

--- a/src/utils/locale.js
+++ b/src/utils/locale.js
@@ -458,7 +458,7 @@ export default class Locale {
         dateParts.seconds = timeParts.seconds;
         dateParts.milliseconds = timeParts.milliseconds;
       } else {
-        var d = new Date(`2000-01-01T${timeAdjust}`);
+        const d = new Date(`2000-01-01T${timeAdjust}`);
         dateParts.hours = d.getHours();
         dateParts.minutes = d.getMinutes();
         dateParts.seconds = d.getSeconds();

--- a/src/utils/locale.js
+++ b/src/utils/locale.js
@@ -456,11 +456,13 @@ export default class Locale {
         dateParts.hours = timeParts.hours;
         dateParts.minutes = timeParts.minutes;
         dateParts.seconds = timeParts.seconds;
+        dateParts.milliseconds = timeParts.milliseconds;
       } else {
-        const timeParts = timeAdjust.split(':');
-        dateParts.hours = +timeParts[0];
-        dateParts.minutes = +timeParts[1];
-        dateParts.seconds = +timeParts[2];
+        var d = new Date(`2000-01-01T${timeAdjust}`);
+        dateParts.hours = d.getHours();
+        dateParts.minutes = d.getMinutes();
+        dateParts.seconds = d.getSeconds();
+        dateParts.milliseconds = d.getMilliseconds();
       }
       date = this.getDateFromParts(dateParts);
     }
@@ -483,9 +485,11 @@ export default class Locale {
       const normDate = new Date(
         date.toLocaleString('en-US', { timeZone: this.timezone }),
       );
+      normDate.setMilliseconds(date.getMilliseconds());
       const diff = normDate.getTime() - date.getTime();
       tzDate = new Date(date.getTime() + diff);
     }
+    const milliseconds = tzDate.getMilliseconds();
     const seconds = tzDate.getSeconds();
     const minutes = tzDate.getMinutes();
     const hours = tzDate.getHours();
@@ -502,6 +506,7 @@ export default class Locale {
     );
     const weekFromEnd = comps.weeks - week + 1;
     const parts = {
+      milliseconds,
       seconds,
       minutes,
       hours,

--- a/tests/unit/specs/DatePicker.spec.js
+++ b/tests/unit/specs/DatePicker.spec.js
@@ -12,6 +12,10 @@ describe('DatePicker', () => {
     });
   });
 
+  function wait(milliseconds) {
+    return new Promise(resolve => setTimeout(resolve, milliseconds));
+  }
+
   describe(':props', () => {
     it(':value - renders a date value', async () => {
       expect(wrapper.find('.id-2000-01-15').exists()).toBe(true);
@@ -24,10 +28,14 @@ describe('DatePicker', () => {
       await wrapper.find('.id-2000-01-04 .vc-day-content').trigger('click');
       // Highlight should NOT appear
       expect(wrapper.find('.id-2000-01-04 .vc-highlight').exists()).toBe(false);
+    });
+    it(':min-date - allows date on minimum date', async () => {
+      await wrapper.setProps({ minDate: new Date(2000, 0, 5) });
       // Day of min date is not disabled
       expect(wrapper.find('.id-2000-01-05 .is-disabled').exists()).toBe(false);
       // Click day of min date
       await wrapper.find('.id-2000-01-05 .vc-day-content').trigger('click');
+      await wait(1);
       // Highlight should appear
       expect(wrapper.find('.id-2000-01-05 .vc-highlight').exists()).toBe(true);
     });
@@ -39,12 +47,30 @@ describe('DatePicker', () => {
       await wrapper.find('.id-2000-01-26 .vc-day-content').trigger('click');
       // Highlight should NOT appear
       expect(wrapper.find('.id-2000-01-26 .vc-highlight').exists()).toBe(false);
+    });
+    it(':max-date - allows date on maximum date', async () => {
+      await wrapper.setProps({ maxDate: new Date(2000, 0, 25) });
       // Day of max date is not disabled
       expect(wrapper.find('.id-2000-01-25 .is-disabled').exists()).toBe(false);
       // Click day of max date
       await wrapper.find('.id-2000-01-25 .vc-day-content').trigger('click');
+      await wait(1);
       // Highlight should appear
       expect(wrapper.find('.id-2000-01-25 .vc-highlight').exists()).toBe(true);
+    });
+    it(':is-required - keeps date when set', async () => {
+      await wrapper.setProps({ isRequired: true });
+      await wrapper.find('.id-2000-01-15 .vc-day-content').trigger('click');
+      expect(wrapper.find('.id-2000-01-15 .vc-highlight').exists()).toBe(true);
+      await wrapper.find('.id-2000-01-15 .vc-day-content').trigger('click');
+      expect(wrapper.find('.id-2000-01-15 .vc-highlight').exists()).toBe(true);
+    });
+    it(':is-required - clears date when not set', async () => {
+      await wrapper.setProps({ isRequired: false });
+      await wrapper.find('.id-2000-01-15 .vc-day-content').trigger('click');
+      expect(wrapper.find('.id-2000-01-15 .vc-highlight').exists()).toBe(true);
+      await wrapper.find('.id-2000-01-15 .vc-day-content').trigger('click');
+      expect(wrapper.find('.id-2000-01-15 .vc-highlight').exists()).toBe(false);
     });
   });
 });

--- a/tests/unit/specs/DatePicker.spec.js
+++ b/tests/unit/specs/DatePicker.spec.js
@@ -60,17 +60,17 @@ describe('DatePicker', () => {
     });
     it(':is-required - keeps date when set', async () => {
       await wrapper.setProps({ isRequired: true });
-      await wrapper.find('.id-2000-01-15 .vc-day-content').trigger('click');
-      expect(wrapper.find('.id-2000-01-15 .vc-highlight').exists()).toBe(true);
-      await wrapper.find('.id-2000-01-15 .vc-day-content').trigger('click');
-      expect(wrapper.find('.id-2000-01-15 .vc-highlight').exists()).toBe(true);
+      await wrapper.find('.id-2000-01-25 .vc-day-content').trigger('click');
+      expect(wrapper.find('.id-2000-01-25 .vc-highlight').exists()).toBe(true);
+      await wrapper.find('.id-2000-01-25 .vc-day-content').trigger('click');
+      expect(wrapper.find('.id-2000-01-25 .vc-highlight').exists()).toBe(true);
     });
     it(':is-required - clears date when not set', async () => {
       await wrapper.setProps({ isRequired: false });
-      await wrapper.find('.id-2000-01-15 .vc-day-content').trigger('click');
-      expect(wrapper.find('.id-2000-01-15 .vc-highlight').exists()).toBe(true);
-      await wrapper.find('.id-2000-01-15 .vc-day-content').trigger('click');
-      expect(wrapper.find('.id-2000-01-15 .vc-highlight').exists()).toBe(false);
+      await wrapper.find('.id-2000-01-25 .vc-day-content').trigger('click');
+      expect(wrapper.find('.id-2000-01-25 .vc-highlight').exists()).toBe(true);
+      await wrapper.find('.id-2000-01-25 .vc-day-content').trigger('click');
+      expect(wrapper.find('.id-2000-01-25 .vc-highlight').exists()).toBe(false);
     });
   });
 });


### PR DESCRIPTION
* Toggle date value to `null` if date is re-selected. This only applies if `is-range` is false.
* Use `is-required` prop to prevent date `null` values on re-select or clearing `input` element
* Prevent hiding picker if disabled date is selected
* Shortens `hideDelay` to prevent multiple rapid date selections
* Adds unit tests for `is-required` prop

Closes #694