### PR TITLE
Improve month & year navigation

### DIFF
--- a/docs/.vuepress/components/github/762.vue
+++ b/docs/.vuepress/components/github/762.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="example">
-    <v-calendar :min-date="minDate" :max-date="maxDate" />
+    <v-calendar :min-date="minDate" :max-date="maxDate" :can-move="canMove" />
   </div>
 </template>
 
@@ -9,9 +9,16 @@ export default {
   githubTitle: `Can't use the popover navigation correctly when set "min-date" or "max-date"`,
   data() {
     return {
-      minDate: new Date(2020, 0, 12),
-      maxDate: new Date(2021, 0, 12),
+      // minDate: new Date(2020, 0, 12),
+      // maxDate: new Date(2021, 0, 12),
+      minDate: null,
+      maxDate: null,
     };
+  },
+  methods: {
+    canMove(page, result) {
+      if (page.month === 2 && page.year === 2020) return false;
+    },
   },
 };
 </script>

--- a/docs/.vuepress/components/github/762.vue
+++ b/docs/.vuepress/components/github/762.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="example">
+    <v-calendar :min-date="minDate" :max-date="maxDate" />
+  </div>
+</template>
+
+<script>
+export default {
+  githubTitle: `Can't use the popover navigation correctly when set "min-date" or "max-date"`,
+  data() {
+    return {
+      minDate: new Date(2020, 0, 12),
+      maxDate: new Date(2021, 0, 12),
+    };
+  },
+};
+</script>

--- a/docs/.vuepress/components/github/762.vue
+++ b/docs/.vuepress/components/github/762.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="example">
-    <v-calendar :min-date="minDate" :max-date="maxDate" :can-move="canMove" />
+    <v-calendar
+      :from-page="{ month: 11, year: 2020 }"
+      :min-date="minDate"
+      :max-date="maxDate"
+      :can-move="canMove"
+    />
   </div>
 </template>
 
@@ -9,10 +14,10 @@ export default {
   githubTitle: `Can't use the popover navigation correctly when set "min-date" or "max-date"`,
   data() {
     return {
-      // minDate: new Date(2020, 0, 12),
-      // maxDate: new Date(2021, 0, 12),
       minDate: null,
       maxDate: null,
+      // minDate: new Date(2020, 10, 10),
+      // maxDate: new Date(2020, 10, 20),
     };
   },
   methods: {

--- a/docs/api/v2.0/calendar.md
+++ b/docs/api/v2.0/calendar.md
@@ -149,6 +149,24 @@ The `.sync` modifier does not work with this prop, unlike `to-page`.
 
 **Default:** `undefined`
 
+### `can-move`
+
+**Type:** Function
+
+**Description:** Function used to determine if navigation to a given page is allowed.
+
+```js
+canMove(page: Object, defaultResult: Boolean): result: Boolean
+```
+
+The `defaultResult` will be `true` or `false`, depending if any of the `min-date`, `min-page`, `max-date` or `max-page` props have also been provided.
+
+In this way, you can override the default navigation behavior of the min and max props.
+
+If no value is returned (`undefined`), the `defaultResult` is used. Otherwise, navigation is enabled if a "truthy" result is returned.
+
+**Default:** `undefined`
+
 ### `attributes`
 
 **Type:** Array[Object]

--- a/docs/changelog/v2.0.md
+++ b/docs/changelog/v2.0.md
@@ -430,3 +430,24 @@ Fixes single use of `highlight.contentStyle` or `highlight.contentClass`
 * Use a default ISO mask for string dates that matches the browser: `YYYY-MM-DDTHH:mm:ss.SSSZ`
 * Add `Z`, `ZZ`, `ZZZ` and `ZZZZ` mask tokens
 * Add unit tests for DatePicker and TimePicker with string dates
+
+## v2.3.0
+
+### Bug Fixes
+
+* Fix bug with disabling certain month and year items if any min or max props are provided.
+
+### Improvements
+
+* Disables navigation to next and previous groups of month and year items when needed. :tada:
+* Adds a `can-move` function prop to `v-calendar` and `v-date-picker` with the signature
+
+```js
+canMove(page: Object, defaultResult: Boolean): result: Boolean
+```
+This function will allow for what pages can be navigated to within the calendar panes or calendar navigation dropdown.
+The `defaultResult` will be `true` or `false`, depending on the default calculated result if any of the `min-date`, `min-page`, `max-date` or `max-page` props have been provided.
+
+In this way, you can override the default navigation behavior of the min and max props.
+
+If no value is returned, the `defaultResult` is used. Otherwise, the returned "truthy" result is used.

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -66,6 +66,22 @@ If `min-date` or `max-date` props are assigned, this will disable navigation for
 <v-calendar :max-date="new Date()" />
 ```
 
+### Disable & Enable Months :tada:
+
+Use the `can-move` function prop to override the default navigation behavior for any given month.
+
+```js
+canMove(page: Object, defaultResult: Boolean): result: Boolean
+```
+
+This function will allow for what pages can be navigated to within the calendar panes or calendar navigation dropdown.
+
+The `defaultResult` will be `true` or `false`, depending if any of the `min-date`, `min-page`, `max-date` or `max-page` props have also been provided.
+
+In this way, you can override the default navigation behavior of the min and max props.
+
+If no value is returned (`undefined`), the `defaultResult` is used. Otherwise, navigation is enabled if a "truthy" result is returned.
+
 ## Key Commands
 
 Both `v-calendar` and `v-date-picker` now support the following key commands for navigation:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v-calendar",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "private": false,
   "description": "A clean and extendable plugin for building simple attributed calendars in Vue.js.",
   "author": "Nathan Reyes <nathanreyes@me.com>",

--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -73,7 +73,11 @@ export default {
       return h(
         'div',
         {
-          class: ['vc-arrow', { 'is-disabled': isDisabled }],
+          class: [
+            'vc-arrow',
+            `is-${isPrev ? 'left' : 'right'}`,
+            { 'is-disabled': isDisabled },
+          ],
           attrs: {
             role: 'button',
           },

--- a/src/components/CalendarNav.vue
+++ b/src/components/CalendarNav.vue
@@ -8,7 +8,7 @@
         role="button"
         class="vc-nav-arrow is-left"
         :class="{ 'is-disabled': !prevItemsEnabled }"
-        tabindex="0"
+        :tabindex="prevItemsEnabled ? 0 : undefined"
         @click="movePrev"
         @keydown="e => onSpaceOrEnter(e, movePrev)"
       >
@@ -32,7 +32,7 @@
         role="button"
         class="vc-nav-arrow is-right"
         :class="{ 'is-disabled': !nextItemsEnabled }"
-        tabindex="0"
+        :tabindex="nextItemsEnabled ? 0 : undefined"
         @click="moveNext"
         @keydown="e => onSpaceOrEnter(e, moveNext)"
       >

--- a/src/components/CalendarNav.vue
+++ b/src/components/CalendarNav.vue
@@ -47,6 +47,7 @@
         v-for="item in activeItems"
         :key="item.label"
         role="button"
+        :data-id="item.id"
         :aria-label="item.ariaLabel"
         :class="getItemClasses(item)"
         :tabindex="item.isDisabled ? undefined : 0"
@@ -63,7 +64,7 @@
 import SvgIcon from './SvgIcon';
 import { childMixin } from '../utils/mixins';
 import { head, last } from '../utils/_';
-import { onSpaceOrEnter } from '../utils/helpers';
+import { onSpaceOrEnter, pad } from '../utils/helpers';
 
 const _yearGroupCount = 12;
 
@@ -171,6 +172,7 @@ export default {
       return this.locale.getMonthDates().map((d, i) => {
         const month = i + 1;
         return {
+          id: `${yearIndex}.${pad(month, 2)}`,
           label: this.locale.format(d, this.masks.navMonths),
           ariaLabel: this.locale.format(d, 'MMMM YYYY'),
           isActive: month === this.month && yearIndex === this.year,
@@ -192,7 +194,7 @@ export default {
           if (enabled) break;
         }
         items.push({
-          year,
+          id: year,
           label: year,
           ariaLabel: year,
           isActive: year === this.year,

--- a/src/components/CalendarNav.vue
+++ b/src/components/CalendarNav.vue
@@ -167,18 +167,20 @@ export default {
     getYearGroupIndex(year) {
       return Math.floor(year / _yearGroupCount);
     },
-    getMonthItems(yearIndex) {
+    getMonthItems(year) {
       const { month: thisMonth, year: thisYear } = this.pageForDate(new Date());
       return this.locale.getMonthDates().map((d, i) => {
         const month = i + 1;
         return {
-          id: `${yearIndex}.${pad(month, 2)}`,
+          month,
+          year,
+          id: `${year}.${pad(month, 2)}`,
           label: this.locale.format(d, this.masks.navMonths),
           ariaLabel: this.locale.format(d, 'MMMM YYYY'),
-          isActive: month === this.month && yearIndex === this.year,
-          isCurrent: month === thisMonth && yearIndex === thisYear,
-          isDisabled: !this.validator({ month, year: yearIndex }),
-          click: () => this.monthClick(month),
+          isActive: month === this.month && year === this.year,
+          isCurrent: month === thisMonth && year === thisYear,
+          isDisabled: !this.validator({ month, year }),
+          click: () => this.monthClick(month, year),
         };
       });
     },
@@ -194,6 +196,7 @@ export default {
           if (enabled) break;
         }
         items.push({
+          year,
           id: year,
           label: year,
           ariaLabel: year,
@@ -205,8 +208,8 @@ export default {
       }
       return items;
     },
-    monthClick(month) {
-      this.$emit('input', { month, year: this.yearIndex });
+    monthClick(month, year) {
+      this.$emit('input', { month, year });
     },
     yearClick(year) {
       this.yearIndex = year;

--- a/src/components/CalendarPane.vue
+++ b/src/components/CalendarPane.vue
@@ -37,6 +37,7 @@ export default {
                 id: this.navPopoverId,
                 contentClass: 'vc-nav-popover-container',
               },
+              ref: 'navPopover',
             },
             [
               // Navigation pane
@@ -146,6 +147,7 @@ export default {
   methods: {
     move(page) {
       this.$emit('update:page', page);
+      this.$refs.navPopover.hide({ hideDelay: 0 });
     },
     refresh() {
       this.$refs.days.forEach(d => d.refresh());

--- a/src/components/Popover.vue
+++ b/src/components/Popover.vue
@@ -410,6 +410,7 @@ export default {
   border-top: inherit;
   border-left: inherit;
   background-color: inherit;
+  user-select: none;
   z-index: -1;
   &.direction-bottom {
     top: 0;

--- a/tests/.prettierrc
+++ b/tests/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "useTabs": false,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "arrowParens": "avoid",
+  "printWidth": 100
+}

--- a/tests/unit/specs/DatePicker.spec.js
+++ b/tests/unit/specs/DatePicker.spec.js
@@ -2,7 +2,6 @@ import { mount } from '@vue/test-utils';
 import DatePicker from '@/components/DatePicker';
 import TimePicker from '@/components/TimePicker';
 import dateValues from '../util/dateValues.json';
-import wait from '../util/wait';
 
 describe('DatePicker', () => {
   describe(':props', () => {

--- a/tests/unit/util/disabledTests.js
+++ b/tests/unit/util/disabledTests.js
@@ -1,7 +1,7 @@
 const disabledTests = [
   // Min date
   {
-    it: 'Disables days, arrows and nav state for min date',
+    it: ':min-date disables days, arrows and nav state',
     props: { fromPage: { month: 11, year: 2020 }, minDate: new Date(2020, 10, 15) },
     disabledDays: [{ start: 1, end: 14 }],
     disabledArrows: ['left'],
@@ -19,7 +19,7 @@ const disabledTests = [
   },
   // Max date
   {
-    it: 'Disables days, arrows and nav state for max date',
+    it: ':max-date disables days, arrows and nav state',
     props: { fromPage: { month: 11, year: 2020 }, maxDate: new Date(2020, 10, 15) },
     disabledDays: [{ start: 16, end: 30 }],
     disabledArrows: ['right'],
@@ -37,7 +37,7 @@ const disabledTests = [
   },
   // Min date and max date
   {
-    it: 'Disables days, arrows and nav state for min and max date',
+    it: ':min-date and :max-date disable days, arrows and nav state',
     props: {
       fromPage: { month: 11, year: 2020 },
       minDate: new Date(2020, 10, 10),
@@ -62,7 +62,7 @@ const disabledTests = [
   },
   // Daily interval
   {
-    it: 'Disables days for daily interval',
+    it: ':disabled-dates disables daily interval',
     props: {
       fromPage: { month: 11, year: 2020 },
       disabledDates: [{ start: new Date(2020, 10, 1), end: null, on: { dailyInterval: 4 } }],
@@ -71,7 +71,8 @@ const disabledTests = [
   },
   // Daily interval with min and max date
   {
-    it: 'Disables days, arrows and nav state for daily interval, min and max date',
+    it:
+      ':min-date, :max-date, :disabled-dates disables days, arrows and nav state for daily interval',
     props: {
       fromPage: { month: 11, year: 2020 },
       disabledDates: [{ start: new Date(2020, 10, 1), end: null, on: { dailyInterval: 4 } }],
@@ -89,6 +90,29 @@ const disabledTests = [
       years: {
         disabledArrows: ['left', 'right'],
         disabledYears: [2016, 2017, 2018, 2019, 2021, 2022, 2023, 2024, 2025, 2026, 2027],
+      },
+    },
+  },
+  // Custom move validator
+  {
+    it: ':can-move disables nav months and years',
+    props: {
+      fromPage: { month: 11, year: 2020 },
+      canMove: ({ month, year }) => {
+        const disableMonths = [1, 3, 6, 9, 12];
+        const disableYears = [2016, 2019, 2022, 2025];
+        return !disableMonths.includes(month) && !disableYears.includes(year);
+      },
+    },
+    disabledArrows: ['right'],
+    nav: {
+      months: {
+        disabledArrows: ['left'],
+        disabledMonths: [1, 3, 6, 9, 12],
+        year: 2020,
+      },
+      years: {
+        disabledYears: [2016, 2019, 2022, 2025],
       },
     },
   },

--- a/tests/unit/util/disabledTests.js
+++ b/tests/unit/util/disabledTests.js
@@ -1,0 +1,97 @@
+const disabledTests = [
+  // Min date
+  {
+    it: 'Disables days, arrows and nav state for min date',
+    props: { fromPage: { month: 11, year: 2020 }, minDate: new Date(2020, 10, 15) },
+    disabledDays: [{ start: 1, end: 14 }],
+    disabledArrows: ['left'],
+    nav: {
+      months: {
+        disabledArrows: ['left'],
+        disabledMonths: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        year: 2020,
+      },
+      years: {
+        disabledArrows: ['left'],
+        disabledYears: [2016, 2017, 2018, 2019],
+      },
+    },
+  },
+  // Max date
+  {
+    it: 'Disables days, arrows and nav state for max date',
+    props: { fromPage: { month: 11, year: 2020 }, maxDate: new Date(2020, 10, 15) },
+    disabledDays: [{ start: 16, end: 30 }],
+    disabledArrows: ['right'],
+    nav: {
+      months: {
+        disabledArrows: ['right'],
+        disabledMonths: [12],
+        year: 2020,
+      },
+      years: {
+        disabledArrows: ['right'],
+        disabledYears: [2021, 2022, 2023, 2024, 2025, 2026, 2027],
+      },
+    },
+  },
+  // Min date and max date
+  {
+    it: 'Disables days, arrows and nav state for min and max date',
+    props: {
+      fromPage: { month: 11, year: 2020 },
+      minDate: new Date(2020, 10, 10),
+      maxDate: new Date(2020, 10, 20),
+    },
+    disabledDays: [
+      { start: 1, end: 9 },
+      { start: 21, end: 30 },
+    ],
+    disabledArrows: ['left', 'right'],
+    nav: {
+      months: {
+        disabledArrows: ['left', 'right'],
+        disabledMonths: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12],
+        year: 2020,
+      },
+      years: {
+        disabledArrows: ['left', 'right'],
+        disabledYears: [2016, 2017, 2018, 2019, 2021, 2022, 2023, 2024, 2025, 2026, 2027],
+      },
+    },
+  },
+  // Daily interval
+  {
+    it: 'Disables days for daily interval',
+    props: {
+      fromPage: { month: 11, year: 2020 },
+      disabledDates: [{ start: new Date(2020, 10, 1), end: null, on: { dailyInterval: 4 } }],
+    },
+    disabledDays: [1, 5, 9, 13, 17, 21, 25, 29],
+  },
+  // Daily interval with min and max date
+  {
+    it: 'Disables days, arrows and nav state for daily interval, min and max date',
+    props: {
+      fromPage: { month: 11, year: 2020 },
+      disabledDates: [{ start: new Date(2020, 10, 1), end: null, on: { dailyInterval: 4 } }],
+      minDate: new Date(2020, 10, 10),
+      maxDate: new Date(2020, 10, 20),
+    },
+    disabledDays: [1, 5, 9, 13, 17, 21, 25, 29, { start: 1, end: 9 }, { start: 21, end: 30 }],
+    disabledArrows: ['left', 'right'],
+    nav: {
+      months: {
+        disabledArrows: ['left', 'right'],
+        disabledMonths: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12],
+        year: 2020,
+      },
+      years: {
+        disabledArrows: ['left', 'right'],
+        disabledYears: [2016, 2017, 2018, 2019, 2021, 2022, 2023, 2024, 2025, 2026, 2027],
+      },
+    },
+  },
+];
+
+module.exports = disabledTests;


### PR DESCRIPTION
### Bug Fixes

* Fix bug with disabling certain month and year items if any min or max props are provided.  Closes #762. Closes #557.

### Improvements

* Disables navigation to next and previous groups of month and year items when needed. :tada:  Closes #340.
* Adds a `can-move` function prop to `v-calendar` and `v-date-picker` with the signature

```js
canMove(page: Object, defaultResult: Boolean): result: Boolean
```
This function will allow for what pages can be navigated to within the calendar panes or calendar navigation dropdown.
The `defaultResult` will be `true` or `false`, depending on the default calculated result if any of the `min-date`, `min-page`, `max-date` or `max-page` props have been provided.

In this way, you can override the default navigation behavior of the min and max props.

If no value is returned (`undefined`), the `defaultResult` is used. Otherwise, the returned "truthy" result is used.

#### Example
```html
<v-calendar :min-date="minDate" :max-date="maxDate" :can-move="canMove" />
```
```js
export default {
  data() {
    return {
      minDate: new Date(2020, 0, 12), // Jan 12th, 2020
      maxDate: new Date(2021, 0, 12), // Jan 12th, 2021
    };
  },
  methods: {
    canMove({ month, year }, defaultResult) {
      // For some reason I don't want the user to navigate to February, 2020
      if (month === 2 && year === 2020) return false;
      // Return default result here, but not strictly required
      return defaultResult; // Will be `false` if before Jan, 2020 or after Jan, 2021
    },
  },
};
```