### PR TITLE
Show iso week numbers on the left side of the calendar

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -38,7 +38,13 @@
         <p>This uses the built version of the plugin</p>
       </section>
       <section>
-        <v-calendar />
+        <div class="selectors">
+          <label for="weeks">
+            <input id="weeks" type="checkbox" v-model="weeks" />
+            Show week numbers
+          </label>
+        </div>
+        <v-calendar :show-weeknumbers="weeks" :key="weeks" />
       </section>
       <section>
         <div class="selectors">
@@ -65,6 +71,7 @@
       data() {
         return {
           mode: 'single',
+          weeks: false,
           date: new Date()
         }
       }

--- a/docs/.vuepress/components/github/786.vue
+++ b/docs/.vuepress/components/github/786.vue
@@ -1,0 +1,56 @@
+<template>
+  <v-date-picker
+    ref="startAt"
+    v-model="date"
+    mode="dateTime"
+    :popover="popover"
+    :masks="masks"
+  >
+    <template #default="{ inputValue, inputEvents }">
+      <div class="flex items-center" v-on="inputEvents">
+        <input
+          :value="inputValue"
+          class="w-full px-6 py-3 placeholder-white bg-transparent border-0 outline-none md:text-tiny md:px-2 md:outline-none md:py-2 lg:px-6 lg:outline-none lg:py-3 ring-0"
+          type="text"
+          :readOnly="true"
+          placeholder="Meetup Starts At"
+        />
+        <div class="flex items-center justify-center h-full px-6">
+          <i class="far fa-calendar-alt" />
+        </div>
+      </div>
+    </template>
+
+    <template #footer>
+      <div class="p-2 text-center bg-gray-100 border-t rounded-b-lg">
+        <button
+          class="px-2 py-1 font-medium text-white bg-blue-500 rounded hover:bg-blue-600"
+          @click="hideAllCalendars"
+        >
+          Close
+        </button>
+      </div>
+    </template>
+  </v-date-picker>
+</template>
+
+<script>
+export default {
+  githubTitle:
+    'how to hide v-date-picker in dateTime mode when clicking on button from footer?',
+  data() {
+    return {
+      date: new Date(),
+      popover: {},
+      masks: {
+        inputDateTime: 'YYYY-MM-DD HH:mm',
+      },
+    };
+  },
+  methods: {
+    hideAllCalendars() {
+      this.$refs.startAt.hidePopover();
+    },
+  },
+};
+</script>

--- a/docs/.vuepress/components/homepage/simple-calendar.vue
+++ b/docs/.vuepress/components/homepage/simple-calendar.vue
@@ -131,6 +131,14 @@
         </v-calendar>
       </div>
     </div>
+    <div class="flex flex-col items-center md:flex-row md:justify-around mb-8">
+      <div class="mb-6">
+        <h3 class="text-base semibold text-gray-700 mb-3">Week numbers</h3>
+        <div class="mb-6">
+          <v-calendar show-weeknumbers />
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 

--- a/docs/api/v2.0/calendar.md
+++ b/docs/api/v2.0/calendar.md
@@ -229,6 +229,14 @@ The `.sync` modifier does not work with this prop, unlike `to-page`.
 
 **Default:** `undefined`
 
+### show-weeknumbers
+
+**Type:** Boolean
+
+**Description:** Shows the (iso) week number on the left side of the week.
+
+**Default:** `undefined`
+
 <!--
 ### 
 

--- a/docs/datepicker.md
+++ b/docs/datepicker.md
@@ -38,7 +38,7 @@ Binding to date ranges is also supported by setting the `is-range` prop.
 <guide-datepicker-simple-range />
 
 ```html
-<v-date-picker value="range" is-range />
+<v-date-picker v-model="range" is-range />
 ```
 
 ```js

--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -282,6 +282,7 @@ export default {
     attributes: [Object, Array],
     trimWeeks: Boolean,
     disablePageSwipe: Boolean,
+    showWeeknumbers: Boolean
   },
   data() {
     return {
@@ -669,6 +670,7 @@ export default {
           movePrevMonth: () => this.move(prevMonthComps),
           moveNextMonth: () => this.move(nextMonthComps),
           refresh: true,
+          showWeeknumbers: this.showWeeknumbers
         };
         // Assign day info
         page.days = this.$locale.getCalendarDays(page);

--- a/src/components/CalendarPane.vue
+++ b/src/components/CalendarPane.vue
@@ -7,6 +7,41 @@ export default {
   name: 'CalendarPane',
   mixins: [childMixin, safeScopedSlotMixin],
   render(h) {
+    const weeknumbers =
+      this.safeScopedSlot('weeknumbers', this.page) ||
+      h(
+        'div',
+        {
+          class: 'vc-weeknumber-grid'
+        },
+        [
+          h(
+            'div',
+            {
+              key: 'weeknumberheader',
+              class: 'vc-weekday'
+            },
+            ['']
+          ),
+          ...this.page.monthComps.isoWeeks.map((w, i) =>
+            h(
+              'div',
+              {
+                key: `w${i}`,
+                class: 'vc-weeknumber'
+              },
+              [h(
+                'span',
+                {
+                  key: `wc${i}`,
+                  class: 'vc-weeknumber-content'
+                },
+                [w]
+              )]
+            ),
+          ),
+        ],
+      );
     // Header
     const header =
       this.safeScopedSlot('header', this.page) ||
@@ -63,13 +98,21 @@ export default {
       ],
     );
 
+    const combined = h(
+      'div',
+      {
+        class: 'vc-combined-container'
+      },
+      [weeknumbers, weeks]
+    );
+
     return h(
       'div',
       {
         class: 'vc-pane',
         ref: 'pane',
       },
-      [header, weeks],
+      [header, this.page.showWeeknumbers ? combined : weeks],
     );
   },
   props: {
@@ -156,6 +199,37 @@ export default {
   }
 }
 
+.vc-combined-container {
+  display: flex;
+}
+
+.vc-weeknumber-grid {
+  display: grid;
+  grid-template-rows: 26px 32px 32px 32px 32px 32px 32px;
+  position: relative;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+  padding: 5px;
+  padding-right: 0px;
+}
+
+.vc-weeknumber {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.vc-weeknumber-content {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: var(--text-xs);
+  font-style: italic;
+  line-height: 28px;
+  width: 28px;
+  height: 28px;
+}
+
 .vc-weeks {
   display: grid;
   grid-template-columns: repeat(7, 1fr);
@@ -163,6 +237,7 @@ export default {
   overflow: auto;
   -webkit-overflow-scrolling: touch;
   padding: 5px;
+  min-width: 250px;
 }
 
 .vc-weekday {

--- a/src/utils/locale.js
+++ b/src/utils/locale.js
@@ -1,5 +1,8 @@
 /* eslint-disable no-bitwise, no-multi-assign, import/no-cycle */
 import toDate from 'date-fns-tz/toDate';
+import getISOWeek from 'date-fns/getISOWeek';
+import getWeeksInMonth from 'date-fns/getWeeksInMonth';
+import addDays from 'date-fns/addDays';
 import DateInfo from './dateInfo';
 import defaultLocales from './defaults/locales';
 import { pad, addPages, arrayHasItems } from './helpers';
@@ -643,11 +646,14 @@ export default class Locale {
     if (!comps) {
       const inLeapYear =
         (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
-      const firstWeekday = new Date(year, month - 1, 1).getDay() + 1;
+      const firstDayOfMonth = new Date(year, month - 1, 1);
+      const firstWeekday = firstDayOfMonth.getDay() + 1;
       const days = month === 2 && inLeapYear ? 29 : daysInMonths[month - 1];
-      const weeks = Math.ceil(
-        (days + Math.abs(firstWeekday - this.firstDayOfWeek)) / daysInWeek,
-      );
+      const weeks = getWeeksInMonth(firstDayOfMonth, {
+        weekStartsOn: this.firstDayOfWeek - 1
+      });
+      const isoWeeks = [...Array(weeks).keys()]
+        .map(wIdx => getISOWeek(addDays(firstDayOfMonth, wIdx * 7)));
       comps = {
         firstDayOfWeek: this.firstDayOfWeek,
         inLeapYear,
@@ -656,6 +662,7 @@ export default class Locale {
         weeks,
         month,
         year,
+        isoWeeks
       };
       this.monthData[key] = comps;
     }


### PR DESCRIPTION
Introduces a new property, `show-weeknumbers`, which if set shows week numbers on the left side of the calendar.

With the property set `<v-calendar show-weeknumbers />` we get something like what is shown in the picture below:
<img width="225" alt="Skärmavbild 2021-02-13 kl  21 25 20" src="https://user-images.githubusercontent.com/18558810/107860866-328e1000-6e42-11eb-97f0-289eec02edbd.png">

Styling for the numbers is controlled by the class `.vc-weeknumber-content`.

A live demo is available [here](https://deploy-preview-790--vcalendar.netlify.app/), scroll down to "Week numbers".