### PR TITLE
Release 2.3.0

### DIFF
--- a/docs/.vuepress/components/github/094.vue
+++ b/docs/.vuepress/components/github/094.vue
@@ -2,6 +2,12 @@
   <div>
     <div class="flex mb-2">
       <div>
+        <input id="iso" type="checkbox" v-model="isIso" />
+        <label for="iso">ISO</label>
+      </div>
+    </div>
+    <div class="flex mb-2">
+      <div>
         <input type="radio" id="left" value="left" v-model="showWeeknumbers" />
         <label for="left">Left</label>
       </div>
@@ -14,7 +20,7 @@
         />
         <label for="left-outside">Left Outside</label>
       </div>
-      <div>
+      <div class="ml-2">
         <input
           type="radio"
           id="right"
@@ -23,7 +29,7 @@
         />
         <label for="right">Right</label>
       </div>
-      <div>
+      <div class="ml-2">
         <input
           type="radio"
           id="right-outside"
@@ -34,16 +40,22 @@
       </div>
     </div>
     <div>
-      <v-calendar :show-weeknumbers="showWeeknumbers" />
+      <v-calendar
+        :from-page="fromPage"
+        :show-weeknumbers="!isIso && showWeeknumbers"
+        :show-iso-weeknumbers="isIso && showWeeknumbers"
+      />
     </div>
   </div>
 </template>
 
 <script>
 export default {
-  githubTitle: '',
+  githubTitle: 'Support for weeknumbers',
   data() {
     return {
+      isIso: false,
+      fromPage: { month: 8, year: 2021 },
       showWeeknumbers: 'left',
     };
   },

--- a/docs/.vuepress/components/github/1000.vue
+++ b/docs/.vuepress/components/github/1000.vue
@@ -1,0 +1,51 @@
+<template>
+  <div>
+    <div class="flex mb-2">
+      <div>
+        <input type="radio" id="left" value="left" v-model="showWeeknumbers" />
+        <label for="left">Left</label>
+      </div>
+      <div class="ml-2">
+        <input
+          type="radio"
+          id="left-outside"
+          value="left-outside"
+          v-model="showWeeknumbers"
+        />
+        <label for="left-outside">Left Outside</label>
+      </div>
+      <div>
+        <input
+          type="radio"
+          id="right"
+          value="right"
+          v-model="showWeeknumbers"
+        />
+        <label for="right">Right</label>
+      </div>
+      <div>
+        <input
+          type="radio"
+          id="right-outside"
+          value="right-outside"
+          v-model="showWeeknumbers"
+        />
+        <label for="right-outside">Right Outside</label>
+      </div>
+    </div>
+    <div>
+      <v-calendar :show-weeknumbers="showWeeknumbers" />
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  githubTitle: '',
+  data() {
+    return {
+      showWeeknumbers: 'left',
+    };
+  },
+};
+</script>

--- a/docs/.vuepress/components/github/781.vue
+++ b/docs/.vuepress/components/github/781.vue
@@ -1,0 +1,35 @@
+<template>
+  <div>
+    <div>Start: {{ range && range.start }}</div>
+    <div>End: {{ range && range.end }}</div>
+    <v-date-picker
+      v-model="range"
+      :min-date="new Date()"
+      mode="dateTime"
+      is24hr
+      is-range
+    >
+      <template v-slot="{ inputValue, inputEvents }">
+        <div class="flex">
+          <input
+            type="text"
+            :value="inputValue.start"
+            v-on="inputEvents.start"
+          />
+          <input type="text" :value="inputValue.end" v-on="inputEvents.end" />
+        </div>
+      </template>
+    </v-date-picker>
+  </div>
+</template>
+
+<script>
+export default {
+  githubTitle: 'is24hr issue when selecting time',
+  data() {
+    return {
+      range: null,
+    };
+  },
+};
+</script>

--- a/docs/.vuepress/components/guide/layouts/weeknumbers.vue
+++ b/docs/.vuepress/components/guide/layouts/weeknumbers.vue
@@ -3,6 +3,7 @@
     <v-calendar
       :show-weeknumbers="!iso && option"
       :show-iso-weeknumbers="iso && option"
+      :first-day-of-week="iso ? 2 : undefined"
     />
   </div>
 </template>

--- a/docs/.vuepress/components/guide/layouts/weeknumbers.vue
+++ b/docs/.vuepress/components/guide/layouts/weeknumbers.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="example">
+    <v-calendar :show-weeknumbers="option" />
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    option: {
+      type: String,
+      default: 'left',
+    },
+  },
+};
+</script>

--- a/docs/.vuepress/components/guide/layouts/weeknumbers.vue
+++ b/docs/.vuepress/components/guide/layouts/weeknumbers.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="example">
-    <v-calendar :show-weeknumbers="option" />
+    <v-calendar
+      :show-weeknumbers="!iso && option"
+      :show-iso-weeknumbers="iso && option"
+    />
   </div>
 </template>
 
@@ -11,6 +14,7 @@ export default {
       type: String,
       default: 'left',
     },
+    iso: Boolean,
   },
 };
 </script>

--- a/docs/.vuepress/components/homepage/custom-calendar.vue
+++ b/docs/.vuepress/components/homepage/custom-calendar.vue
@@ -10,6 +10,7 @@
       :attributes="attributes"
       disable-page-swipe
       is-expanded
+      show-weeknumbers
     >
       <template v-slot:day-content="{ day, attributes }">
         <div class="flex flex-col h-full z-10 overflow-hidden">

--- a/docs/.vuepress/components/homepage/custom-calendar.vue
+++ b/docs/.vuepress/components/homepage/custom-calendar.vue
@@ -10,7 +10,6 @@
       :attributes="attributes"
       disable-page-swipe
       is-expanded
-      show-weeknumbers
     >
       <template v-slot:day-content="{ day, attributes }">
         <div class="flex flex-col h-full z-10 overflow-hidden">
@@ -18,6 +17,7 @@
           <div class="flex-grow overflow-y-auto overflow-x-auto">
             <p
               v-for="attr in attributes"
+              :key="attr.key"
               class="text-xs leading-tight rounded-sm p-1 mt-0 mb-1"
               :class="attr.customData.class"
             >

--- a/docs/.vuepress/components/homepage/multi-calendar.vue
+++ b/docs/.vuepress/components/homepage/multi-calendar.vue
@@ -5,8 +5,11 @@
       Responsive multi-row and column layouts
     </h3>
     <div class="flex justify-center">
-      <v-calendar :rows="2" :columns="$screens({ default: 1, lg: 2 })" />
+      <v-calendar
+        show-weeknumbers="outside"
+        :rows="2"
+        :columns="$screens({ default: 1, lg: 2 })"
+      />
     </div>
   </div>
 </template>
-    

--- a/docs/.vuepress/components/homepage/multi-calendar.vue
+++ b/docs/.vuepress/components/homepage/multi-calendar.vue
@@ -5,11 +5,7 @@
       Responsive multi-row and column layouts
     </h3>
     <div class="flex justify-center">
-      <v-calendar
-        show-weeknumbers="outside"
-        :rows="2"
-        :columns="$screens({ default: 1, lg: 2 })"
-      />
+      <v-calendar :rows="2" :columns="$screens({ default: 1, lg: 2 })" />
     </div>
   </div>
 </template>

--- a/docs/.vuepress/components/homepage/simple-calendar.vue
+++ b/docs/.vuepress/components/homepage/simple-calendar.vue
@@ -7,7 +7,7 @@
     <div class="flex flex-col items-center md:flex-row md:justify-around">
       <div class="mb-6">
         <h3 class="text-base semibold text-gray-700 mb-3">Highlights</h3>
-        <v-calendar :attributes="highlights" ref="cal" />
+        <v-calendar :attributes="highlights" ref="cal" show-weeknumbers />
       </div>
       <div class="mb-6">
         <h3 class="text-base semibold text-gray-700 mb-3">Dots</h3>
@@ -136,6 +136,12 @@
         <h3 class="text-base semibold text-gray-700 mb-3">Week numbers</h3>
         <div class="mb-6">
           <v-calendar show-weeknumbers />
+        </div>
+      </div>
+      <div class="mb-6">
+        <h3 class="text-base semibold text-gray-700 mb-3">Week numbers</h3>
+        <div class="mb-6">
+          <v-calendar show-weeknumbers="outside" />
         </div>
       </div>
     </div>

--- a/docs/.vuepress/components/homepage/simple-calendar.vue
+++ b/docs/.vuepress/components/homepage/simple-calendar.vue
@@ -134,15 +134,19 @@
     <h2>Week Numbers</h2>
     <div class="flex flex-col items-center md:flex-row md:justify-around mb-8">
       <div class="mb-6">
-        <h3 class="text-base semibold text-gray-700 mb-3">Inside Calendar</h3>
+        <h3 class="text-base semibold text-gray-700 mb-3">
+          Default Left Inside
+        </h3>
         <div class="mb-6">
           <v-calendar show-weeknumbers />
         </div>
       </div>
       <div class="mb-6">
-        <h3 class="text-base semibold text-gray-700 mb-3">Outside Calendar</h3>
+        <h3 class="text-base semibold text-gray-700 mb-3">
+          Right and Outside Options
+        </h3>
         <div class="mb-6">
-          <v-calendar show-weeknumbers="left-outside" />
+          <v-calendar show-weeknumbers="right-outside" />
         </div>
       </div>
     </div>

--- a/docs/.vuepress/components/homepage/simple-calendar.vue
+++ b/docs/.vuepress/components/homepage/simple-calendar.vue
@@ -143,10 +143,10 @@
       </div>
       <div class="mb-6">
         <h3 class="text-base semibold text-gray-700 mb-3">
-          Right and Outside Options
+          ISO, Right and Outside Options
         </h3>
         <div class="mb-6">
-          <v-calendar show-weeknumbers="right-outside" />
+          <v-calendar show-iso-weeknumbers="right-outside" />
         </div>
       </div>
     </div>

--- a/docs/.vuepress/components/homepage/simple-calendar.vue
+++ b/docs/.vuepress/components/homepage/simple-calendar.vue
@@ -1,13 +1,13 @@
 <template>
   <div class="section">
-    <h2>Simple Calendars</h2>
+    <h2>Calendar Attributes</h2>
     <h3>
       Show highlights, dots, bars and custom popovers
     </h3>
     <div class="flex flex-col items-center md:flex-row md:justify-around">
       <div class="mb-6">
         <h3 class="text-base semibold text-gray-700 mb-3">Highlights</h3>
-        <v-calendar :attributes="highlights" ref="cal" show-weeknumbers />
+        <v-calendar :attributes="highlights" ref="cal" />
       </div>
       <div class="mb-6">
         <h3 class="text-base semibold text-gray-700 mb-3">Dots</h3>
@@ -131,17 +131,18 @@
         </v-calendar>
       </div>
     </div>
+    <h2>Week Numbers</h2>
     <div class="flex flex-col items-center md:flex-row md:justify-around mb-8">
       <div class="mb-6">
-        <h3 class="text-base semibold text-gray-700 mb-3">Week numbers</h3>
+        <h3 class="text-base semibold text-gray-700 mb-3">Inside Calendar</h3>
         <div class="mb-6">
           <v-calendar show-weeknumbers />
         </div>
       </div>
       <div class="mb-6">
-        <h3 class="text-base semibold text-gray-700 mb-3">Week numbers</h3>
+        <h3 class="text-base semibold text-gray-700 mb-3">Outside Calendar</h3>
         <div class="mb-6">
-          <v-calendar show-weeknumbers="outside" />
+          <v-calendar show-weeknumbers="left-outside" />
         </div>
       </div>
     </div>

--- a/docs/.vuepress/components/homepage/simple-calendar.vue
+++ b/docs/.vuepress/components/homepage/simple-calendar.vue
@@ -138,7 +138,7 @@
           Default Left Inside
         </h3>
         <div class="mb-6">
-          <v-calendar show-weeknumbers />
+          <v-calendar :from-page="{ month: 1, year: 2021 }" show-weeknumbers />
         </div>
       </div>
       <div class="mb-6">
@@ -146,7 +146,10 @@
           ISO, Right and Outside Options
         </h3>
         <div class="mb-6">
-          <v-calendar show-iso-weeknumbers="right-outside" />
+          <v-calendar
+            :from-page="{ month: 1, year: 2021 }"
+            show-iso-weeknumbers="right-outside"
+          />
         </div>
       </div>
     </div>

--- a/docs/api/v2.0/calendar.md
+++ b/docs/api/v2.0/calendar.md
@@ -207,7 +207,7 @@ The `.sync` modifier does not work with this prop, unlike `to-page`.
 
 ### `locale`
 
-**Type:** String, Object
+**Type:** String | Object
 
 **Description:** The locale identifier or locale configuration to use for displaying the calendar.
 
@@ -229,11 +229,11 @@ The `.sync` modifier does not work with this prop, unlike `to-page`.
 
 **Default:** `undefined`
 
-### show-weeknumbers
+### `show-weeknumbers`
 
-**Type:** Boolean
+**Type:** Boolean | String
 
-**Description:** Shows the (iso) week number on the left side of the week.
+**Description:** Shows the (iso) week number on the left side of the calendar (Boolean) or on a specified side of the calendar (`left`, `left-outside`, `right`, `right-outside`).
 
 **Default:** `undefined`
 

--- a/docs/api/v2.0/calendar.md
+++ b/docs/api/v2.0/calendar.md
@@ -262,9 +262,22 @@ The `.sync` modifier does not work with this prop, unlike `to-page`.
 
 **Params:** [`page`](./page-object.md)
 
+### `weeknumberclick`
+
+**Description:** Forwarded from the `click` event for the weeknumber content element.
+
+**Params:**: Week info object.
+```js
+{
+  isoWeek: Number, // Iso week number of the weeknumber clicked
+  days: [Day], // List of day objects for the weeknumber clicked
+  event: MouseEvent, // Native event emitted
+}
+```
+
 ### `dayclick`
 
-**Description:** Forwarded from the `mouseclick` event for the day content element.
+**Description:** Forwarded from the `click` event for the day content element.
 
 **Params:** [`day`](./day-object.md)
 

--- a/docs/api/v2.0/calendar.md
+++ b/docs/api/v2.0/calendar.md
@@ -213,7 +213,7 @@ The `.sync` modifier does not work with this prop, unlike `to-page`.
 
 **Default:** `undefined` [Resolved by defaults or detected locale if not completely specified](./defaults.md#locale)
 
-### `timezone` :tada:
+### `timezone`
 
 **Type:** String
 
@@ -221,19 +221,27 @@ The `.sync` modifier does not work with this prop, unlike `to-page`.
 
 **Default:** `undefined` [Resolved by defaults or detected timezone if not completely specified](./defaults.md#locale)
 
+### `show-weeknumbers`
+
+**Type:** Boolean | String
+
+**Description:** Shows the week number on the left side of the calendar (Boolean) or on a specified side of the calendar (`left`, `left-outside`, `right`, `right-outside`).
+
+**Default:** `undefined`
+
+### `show-iso-weeknumbers`
+
+**Type:** Boolean | String
+
+**Description:** Shows the ISO week number on the left side of the calendar (Boolean) or on a specified side of the calendar (`left`, `left-outside`, `right`, `right-outside`).
+
+**Default:** `undefined`
+
 ### `disable-page-swipe`
 
 **Type:** Boolean
 
 **Description:** Disables swipe detection for navigating forwards and backwards.
-
-**Default:** `undefined`
-
-### `show-weeknumbers`
-
-**Type:** Boolean | String
-
-**Description:** Shows the (iso) week number on the left side of the calendar (Boolean) or on a specified side of the calendar (`left`, `left-outside`, `right`, `right-outside`).
 
 **Default:** `undefined`
 

--- a/docs/api/v2.0/day-object.md
+++ b/docs/api/v2.0/day-object.md
@@ -40,13 +40,25 @@ pageClass: docs-page
 
 **Type:** Number
 
-**Description:** Week number form the start of the month (1 - 6).
+**Description:** Week number from the start of the month (1 - 6).
 
 ### `weekFromEnd`
 
 **Type:** Number
 
 **Description:** Week number from the end of the month (1 - 6).
+
+### `weeknumber`
+
+**Type:** Number
+
+**Description:** Week number of the year (usually 1 - 52).
+
+### `isoWeeknumber`
+
+**Type:** Number
+
+**Description:** ISO year week number of the year (usually 1 - 52).
 
 ### `month`
 

--- a/docs/changelog/v2.0.md
+++ b/docs/changelog/v2.0.md
@@ -470,6 +470,7 @@ Fixes single use of `highlight.contentStyle` or `highlight.contentClass`
 
 ### Bug Fixes
 * Fix `trim-weeks` missing dates if `firstDayOfWeek !== 1`
+* Fix input format on calendar hide
 
 ### Improvements
 

--- a/docs/changelog/v2.0.md
+++ b/docs/changelog/v2.0.md
@@ -474,3 +474,11 @@ Fixes single use of `highlight.contentStyle` or `highlight.contentClass`
 ### Improvements
 
 * Add `show-weeknumbers` prop (Boolean | String) with support for `left`, `left-outside`, `right` or `right-outside` positions
+* Add `weeknumberclick` event that emits week data on click
+```js
+{
+  isoWeek: Number, // Iso week number of the weeknumber clicked
+  days: [Day], // List of day objects for the weeknumber clicked
+  event: MouseEvent, // Native event emitted
+}
+```

--- a/docs/changelog/v2.0.md
+++ b/docs/changelog/v2.0.md
@@ -465,3 +465,12 @@ Fixes single use of `highlight.contentStyle` or `highlight.contentClass`
 
 * Add `modelConfig.fillDate` parameter to fill missing date parts
 * Provide `popover` options as defaults for `showPopover`, `hidePopover`, `togglePopover`
+
+## v2.3.0
+
+### Bug Fixes
+* Fix `trim-weeks` missing dates if `firstDayOfWeek !== 1`
+
+### Improvements
+
+* Add `show-weeknumbers` prop

--- a/docs/changelog/v2.0.md
+++ b/docs/changelog/v2.0.md
@@ -473,4 +473,4 @@ Fixes single use of `highlight.contentStyle` or `highlight.contentClass`
 
 ### Improvements
 
-* Add `show-weeknumbers` prop
+* Add `show-weeknumbers` prop (Boolean | String) with support for `left`, `left-outside`, `right` or `right-outside` positions

--- a/docs/changelog/v2.0.md
+++ b/docs/changelog/v2.0.md
@@ -471,6 +471,7 @@ Fixes single use of `highlight.contentStyle` or `highlight.contentClass`
 ### Bug Fixes
 * Fix `trim-weeks` missing dates if `firstDayOfWeek !== 1`
 * Fix input format on calendar hide
+* Fix date range normalization for time and input updates
 
 ### Improvements
 

--- a/docs/datepicker.md
+++ b/docs/datepicker.md
@@ -1,5 +1,5 @@
 ---
-title: 'Date & Time Picker :tada:'
+title: Date & Time Picker
 sidebarDepth: 2
 ---
 

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -94,11 +94,11 @@ To display ISO week numbers, use the `show-iso-weeknumbers` prop with the same c
 <guide-layouts-weeknumbers iso />
 
 ```html
-<v-calendar show-iso-weeknumbers />
+<v-calendar :first-day-of-week="2" show-iso-weeknumbers />
 ```
 
 :::warning
-For the ISO week date standard (ISO-8601), weeks start on **Monday** and end on **Sunday**. If the `firstDayOfWeek` setting is different, this could result in 2 weeks displaying the same week number.
+For the ISO week date standard (ISO-8601), weeks start on **Monday** and end on **Sunday**. If the `firstDayOfWeek` setting is different (US), this could result in 2 weeks displaying the same week number in certain months.
 :::
 
 ## Multiple Rows & Columns

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -51,7 +51,7 @@ However, these empty weeks can be 'trimmed' by setting the `trim-weeks` prop.
 
 ## Week Numbers :tada:
 
-Show iso week numbers in the calendar using the `show-weeknumbers` prop.
+Show week numbers in the calendar using the `show-weeknumbers` prop.
 
 <guide-layouts-weeknumbers />
 
@@ -63,13 +63,15 @@ By default, this will display the numbers inside the calendar pane.
 
 Alternatively, you can display the week numbers outside the calendar or on the right side by providing a value for the prop.
 
+#### Left Outside
+
 <guide-layouts-weeknumbers option="left-outside" />
 
 ```html
 <v-calendar show-weeknumbers="left-outside ">
 ```
 
-Or even on the right side.
+#### Right
 
 <guide-layouts-weeknumbers option="right" />
 
@@ -77,11 +79,27 @@ Or even on the right side.
 <v-calendar show-weeknumbers="right">
 ```
 
+#### Right Outside
+
 <guide-layouts-weeknumbers option="right-outside" />
 
 ```html
 <v-calendar show-weeknumbers="right-outside">
 ```
+
+### ISO Week Numbers
+
+To display ISO week numbers, use the `show-iso-weeknumbers` prop with the same convention as `show-weeknumbers`. If both are assigned, the `show-weeknumbers` prop takes precendence.
+
+<guide-layouts-weeknumbers iso />
+
+```html
+<v-calendar show-iso-weeknumbers />
+```
+
+:::warning
+For the ISO week date standard (ISO-8601), weeks start on **Monday** and end on **Sunday**. If the `firstDayOfWeek` setting is different, this could result in 2 weeks displaying the same week number.
+:::
 
 ## Multiple Rows & Columns
 

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -49,6 +49,40 @@ However, these empty weeks can be 'trimmed' by setting the `trim-weeks` prop.
 <v-calendar trim-weeks>
 ```
 
+## Week Numbers
+
+Show iso week numbers in the calendar using the `show-weeknumbers` prop.
+
+<guide-layouts-weeknumbers />
+
+```html
+<v-calendar show-weeknumbers />
+```
+
+By default, this will display the numbers inside the calendar pane.
+
+Alternatively, you can display the week numbers outside the calendar or on the right side by providing a value for the prop.
+
+<guide-layouts-weeknumbers option="left-outside" />
+
+```html
+<v-calendar show-weeknumbers="left-outside ">
+```
+
+Or even on the right side.
+
+<guide-layouts-weeknumbers option="right" />
+
+```html
+<v-calendar show-weeknumbers="right">
+```
+
+<guide-layouts-weeknumbers option="right-outside" />
+
+```html
+<v-calendar show-weeknumbers="right-outside">
+```
+
 ## Multiple Rows & Columns
 
 Use the `rows` and `columns` props to create multi-row and multi-column static layouts.

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -49,7 +49,7 @@ However, these empty weeks can be 'trimmed' by setting the `trim-weeks` prop.
 <v-calendar trim-weeks>
 ```
 
-## Week Numbers
+## Week Numbers :tada:
 
 Show iso week numbers in the calendar using the `show-weeknumbers` prop.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v-calendar",
-  "version": "2.2.4",
+  "version": "2.3.0",
   "private": false,
   "description": "A clean and extendable plugin for building simple attributed calendars in Vue.js.",
   "author": "Nathan Reyes <nathanreyes@me.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v-calendar",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "private": false,
   "description": "A clean and extendable plugin for building simple attributed calendars in Vue.js.",
   "author": "Nathan Reyes <nathanreyes@me.com>",

--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -38,15 +38,24 @@ export default {
   name: 'Calendar',
   render(h) {
     // Renderer for calendar panes
-    const panes = this.pages.map((page, i) =>
-      h(CalendarPane, {
+    const panes = this.pages.map((page, i) => {
+      const position = i + 1;
+      const row = Math.ceil((i + 1) / this.columns);
+      const rowFromEnd = this.rows - row + 1;
+      const column = position % this.columns || this.columns;
+      const columnFromEnd = this.columns - column + 1;
+      return h(CalendarPane, {
         attrs: {
           ...this.$attrs,
           attributes: this.store,
         },
         props: {
           page,
-          position: i + 1,
+          position,
+          row,
+          rowFromEnd,
+          column,
+          columnFromEnd,
           titlePosition: this.titlePosition_,
         },
         on: {
@@ -64,8 +73,8 @@ export default {
         key: page.key,
         ref: 'pages',
         refInFor: true,
-      }),
-    );
+      });
+    });
     // Renderer for calendar arrows
     const getArrowButton = isPrev => {
       const click = () => this.move(isPrev ? -this.step_ : this.step_);

--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -282,7 +282,7 @@ export default {
     attributes: [Object, Array],
     trimWeeks: Boolean,
     disablePageSwipe: Boolean,
-    showWeeknumbers: Boolean
+    showWeeknumbers: String,
   },
   data() {
     return {
@@ -670,7 +670,7 @@ export default {
           movePrevMonth: () => this.move(prevMonthComps),
           moveNextMonth: () => this.move(nextMonthComps),
           refresh: true,
-          showWeeknumbers: this.showWeeknumbers
+          showWeeknumbers: this.showWeeknumbers,
         };
         // Assign day info
         page.days = this.$locale.getCalendarDays(page);

--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -282,7 +282,6 @@ export default {
     attributes: [Object, Array],
     trimWeeks: Boolean,
     disablePageSwipe: Boolean,
-    showWeeknumbers: String,
   },
   data() {
     return {
@@ -670,7 +669,6 @@ export default {
           movePrevMonth: () => this.move(prevMonthComps),
           moveNextMonth: () => this.move(nextMonthComps),
           refresh: true,
-          showWeeknumbers: this.showWeeknumbers,
         };
         // Assign day info
         page.days = this.$locale.getCalendarDays(page);

--- a/src/components/CalendarPane.vue
+++ b/src/components/CalendarPane.vue
@@ -58,7 +58,8 @@ export default {
       );
     }
 
-    const getWeeknumberCell = day =>
+    // Weeknumber cell
+    const getWeeknumberCell = isoWeek =>
       h(
         'div',
         {
@@ -69,8 +70,17 @@ export default {
             'span',
             {
               class: ['vc-weeknumber-content', `is-${this.showWeeknumbers_}`],
+              on: {
+                click: event => {
+                  this.$emit('weeknumberclick', {
+                    isoWeek,
+                    days: this.page.days.filter(d => d.isoWeek === isoWeek),
+                    event,
+                  });
+                },
+              },
             },
-            [day.isoWeek],
+            [isoWeek],
           ),
         ],
       );
@@ -78,14 +88,14 @@ export default {
     // Day cells
     const dayCells = [];
     const { daysInWeek } = this.locale;
-
     this.page.days.forEach((day, i) => {
       const mod = i % daysInWeek;
+      // Insert weeknumber cell on left side if needed
       if (
         (showWeeknumbersLeft && mod === 0) ||
         (showWeeknumbersRight && mod === daysInWeek)
       ) {
-        dayCells.push(getWeeknumberCell(day));
+        dayCells.push(getWeeknumberCell(day.isoWeek));
       }
       dayCells.push(
         h(CalendarDay, {
@@ -101,8 +111,9 @@ export default {
           refInFor: true,
         }),
       );
+      // Insert weeknumber cell on right side if needed
       if (showWeeknumbersRight && mod === daysInWeek - 1) {
-        dayCells.push(getWeeknumberCell(day));
+        dayCells.push(getWeeknumberCell(day.isoWeek));
       }
     });
 

--- a/src/components/CalendarPane.vue
+++ b/src/components/CalendarPane.vue
@@ -43,10 +43,6 @@ export default {
 
     const showWeeknumbersLeft = this.showWeeknumbers_.startsWith('left');
     const showWeeknumbersRight = this.showWeeknumbers_.startsWith('right');
-    const isEmbedded =
-      (showWeeknumbersLeft && this.column > 1) ||
-      (showWeeknumbersRight && this.columnFromEnd > 1);
-
     if (showWeeknumbersLeft) {
       weekdayCells.unshift(
         h('div', {
@@ -71,11 +67,7 @@ export default {
           h(
             'span',
             {
-              class: [
-                'vc-weeknumber-content',
-                `is-${this.showWeeknumbers_}`,
-                isEmbedded ? 'is-embedded' : '',
-              ],
+              class: ['vc-weeknumber-content', `is-${this.showWeeknumbers_}`],
             },
             [day.isoWeek],
           ),
@@ -154,7 +146,10 @@ export default {
   computed: {
     showWeeknumbers_() {
       if (this.showWeeknumbers == null) return '';
-      return this.showWeeknumbers || 'left';
+      if (this.showWeeknumbers.startsWith('right')) {
+        return this.columnFromEnd > 1 ? 'right' : this.showWeeknumbers;
+      }
+      return this.column > 1 ? 'left' : this.showWeeknumbers;
     },
     navVisibility_() {
       return this.propOrDefault('navVisibility', 'navVisibility');
@@ -255,16 +250,10 @@ export default {
   &.is-left-outside {
     position: absolute;
     left: var(--weeknumber-offset);
-    &.is-embedded {
-      left: var(--weeknumber-offset-embedded);
-    }
   }
   &.is-right-outside {
     position: absolute;
     right: var(--weeknumber-offset);
-    &.is-embedded {
-      right: var(--weeknumber-offset-embedded);
-    }
   }
 }
 

--- a/src/components/CalendarPane.vue
+++ b/src/components/CalendarPane.vue
@@ -40,7 +40,7 @@ export default {
         [wl],
       ),
     );
-    if (this.page.showWeeknumbers) {
+    if (this.showWeeknumbers_) {
       weekdayCells.unshift(
         h('div', {
           class: 'vc-weekday',
@@ -50,10 +50,13 @@ export default {
 
     // Day cells
     const dayCells = [];
-    const { days, showWeeknumbers } = this.page;
     const { daysInWeek } = this.locale;
-    days.forEach((day, i) => {
-      if (showWeeknumbers && i % daysInWeek === 0) {
+    this.page.days.forEach((day, i) => {
+      const mod = i % daysInWeek;
+      const showLeft = this.showWeeknumbers_.startsWith('left') && mod === 0;
+      const showRight =
+        this.showWeeknumbers_.startsWith('right') && mod === daysInWeek;
+      if (showLeft || showRight) {
         dayCells.push(
           h(
             'div',
@@ -64,10 +67,10 @@ export default {
               h(
                 'span',
                 {
-                  class: {
-                    'vc-weeknumber-content': true,
-                    [`is-${showWeeknumbers}`]: showWeeknumbers.length,
-                  },
+                  class: [
+                    'vc-weeknumber-content',
+                    `is-${this.showWeeknumbers_}`,
+                  ],
                 },
                 [day.isoWeek],
               ),
@@ -96,7 +99,7 @@ export default {
       {
         class: {
           'vc-weeks': true,
-          'vc-show-weeknumbers': this.page.showWeeknumbers,
+          'vc-show-weeknumbers': this.showWeeknumbers_,
         },
       },
       [weekdayCells, dayCells],
@@ -117,8 +120,16 @@ export default {
     position: Number,
     titlePosition: String,
     navVisibility: String,
+    showWeeknumbers: String,
   },
   computed: {
+    showWeeknumbers_() {
+      let { showWeeknumbers } = this;
+      if (showWeeknumbers !== undefined) {
+        showWeeknumbers = showWeeknumbers || 'left';
+      }
+      return showWeeknumbers;
+    },
     navVisibility_() {
       return this.propOrDefault('navVisibility', 'navVisibility');
     },
@@ -216,9 +227,12 @@ export default {
   margin-top: 2px;
   color: var(--gray-500);
   user-select: none;
-  &.is-outside {
+  &.is-left-outside {
     position: absolute;
     left: -32px;
+  }
+  &.is-right-outside {
+    position: absolute;
   }
 }
 

--- a/src/components/CalendarPane.vue
+++ b/src/components/CalendarPane.vue
@@ -158,8 +158,9 @@ export default {
   computed: {
     showWeeknumbers_() {
       if (this.showWeeknumbers == null) return '';
-      if (isBoolean(this.showWeeknumbers))
+      if (isBoolean(this.showWeeknumbers)) {
         return this.showWeeknumbers ? 'left' : '';
+      }
       if (this.showWeeknumbers.startsWith('right')) {
         return this.columnFromEnd > 1 ? 'right' : this.showWeeknumbers;
       }

--- a/src/components/CalendarPane.vue
+++ b/src/components/CalendarPane.vue
@@ -40,43 +40,52 @@ export default {
         [wl],
       ),
     );
-    if (this.showWeeknumbers_) {
+
+    const showWeeknumbersLeft = this.showWeeknumbers_.startsWith('left');
+    const showWeeknumbersRight = this.showWeeknumbers_.startsWith('right');
+
+    if (showWeeknumbersLeft) {
       weekdayCells.unshift(
+        h('div', {
+          class: 'vc-weekday',
+        }),
+      );
+    } else if (showWeeknumbersRight) {
+      weekdayCells.push(
         h('div', {
           class: 'vc-weekday',
         }),
       );
     }
 
+    const getWeeknumberCell = day =>
+      h(
+        'div',
+        {
+          class: ['vc-weeknumber'],
+        },
+        [
+          h(
+            'span',
+            {
+              class: ['vc-weeknumber-content', `is-${this.showWeeknumbers_}`],
+            },
+            [day.isoWeek],
+          ),
+        ],
+      );
+
     // Day cells
     const dayCells = [];
     const { daysInWeek } = this.locale;
+
     this.page.days.forEach((day, i) => {
       const mod = i % daysInWeek;
-      const showLeft = this.showWeeknumbers_.startsWith('left') && mod === 0;
-      const showRight =
-        this.showWeeknumbers_.startsWith('right') && mod === daysInWeek;
-      if (showLeft || showRight) {
-        dayCells.push(
-          h(
-            'div',
-            {
-              class: ['vc-weeknumber'],
-            },
-            [
-              h(
-                'span',
-                {
-                  class: [
-                    'vc-weeknumber-content',
-                    `is-${this.showWeeknumbers_}`,
-                  ],
-                },
-                [day.isoWeek],
-              ),
-            ],
-          ),
-        );
+      if (
+        (showWeeknumbersLeft && mod === 0) ||
+        (showWeeknumbersRight && mod === daysInWeek)
+      ) {
+        dayCells.push(getWeeknumberCell(day));
       }
       dayCells.push(
         h(CalendarDay, {
@@ -92,6 +101,9 @@ export default {
           refInFor: true,
         }),
       );
+      if (showWeeknumbersRight && mod === daysInWeek - 1) {
+        dayCells.push(getWeeknumberCell(day));
+      }
     });
 
     const weeks = h(
@@ -100,6 +112,8 @@ export default {
         class: {
           'vc-weeks': true,
           'vc-show-weeknumbers': this.showWeeknumbers_,
+          'is-left': showWeeknumbersLeft,
+          'is-right': showWeeknumbersRight,
         },
       },
       [weekdayCells, dayCells],
@@ -124,11 +138,8 @@ export default {
   },
   computed: {
     showWeeknumbers_() {
-      let { showWeeknumbers } = this;
-      if (showWeeknumbers !== undefined) {
-        showWeeknumbers = showWeeknumbers || 'left';
-      }
-      return showWeeknumbers;
+      if (this.showWeeknumbers == null) return '';
+      return this.showWeeknumbers || 'left';
     },
     navVisibility_() {
       return this.propOrDefault('navVisibility', 'navVisibility');
@@ -229,10 +240,11 @@ export default {
   user-select: none;
   &.is-left-outside {
     position: absolute;
-    left: -32px;
+    left: var(--weeknumber-offset);
   }
   &.is-right-outside {
     position: absolute;
+    right: var(--weeknumber-offset);
   }
 }
 
@@ -246,6 +258,9 @@ export default {
   min-width: 250px;
   &.vc-show-weeknumbers {
     grid-template-columns: auto repeat(7, 1fr);
+    &.is-right {
+      grid-template-columns: repeat(7, 1fr) auto;
+    }
   }
 }
 

--- a/src/components/CalendarPane.vue
+++ b/src/components/CalendarPane.vue
@@ -43,6 +43,9 @@ export default {
 
     const showWeeknumbersLeft = this.showWeeknumbers_.startsWith('left');
     const showWeeknumbersRight = this.showWeeknumbers_.startsWith('right');
+    const isEmbedded =
+      (showWeeknumbersLeft && this.column > 1) ||
+      (showWeeknumbersRight && this.columnFromEnd > 1);
 
     if (showWeeknumbersLeft) {
       weekdayCells.unshift(
@@ -68,7 +71,11 @@ export default {
           h(
             'span',
             {
-              class: ['vc-weeknumber-content', `is-${this.showWeeknumbers_}`],
+              class: [
+                'vc-weeknumber-content',
+                `is-${this.showWeeknumbers_}`,
+                isEmbedded ? 'is-embedded' : '',
+              ],
             },
             [day.isoWeek],
           ),
@@ -122,7 +129,11 @@ export default {
     return h(
       'div',
       {
-        class: 'vc-pane',
+        class: [
+          'vc-pane',
+          `row-from-end-${this.rowFromEnd}`,
+          `column-from-end-${this.columnFromEnd}`,
+        ],
         ref: 'pane',
       },
       [header, weeks],
@@ -132,6 +143,10 @@ export default {
   props: {
     page: Object,
     position: Number,
+    row: Number,
+    rowFromEnd: Number,
+    column: Number,
+    columnFromEnd: Number,
     titlePosition: String,
     navVisibility: String,
     showWeeknumbers: String,
@@ -232,7 +247,6 @@ export default {
   font-size: var(--text-xs);
   font-weight: var(--font-medium);
   font-style: italic;
-  /* line-height: 28px; */
   width: 28px;
   height: 28px;
   margin-top: 2px;
@@ -241,10 +255,16 @@ export default {
   &.is-left-outside {
     position: absolute;
     left: var(--weeknumber-offset);
+    &.is-embedded {
+      left: var(--weeknumber-offset-embedded);
+    }
   }
   &.is-right-outside {
     position: absolute;
     right: var(--weeknumber-offset);
+    &.is-embedded {
+      right: var(--weeknumber-offset-embedded);
+    }
   }
 }
 

--- a/src/components/CalendarPane.vue
+++ b/src/components/CalendarPane.vue
@@ -59,7 +59,7 @@ export default {
     }
 
     // Weeknumber cell
-    const getWeeknumberCell = isoWeek =>
+    const getWeeknumberCell = weeknumber =>
       h(
         'div',
         {
@@ -73,14 +73,16 @@ export default {
               on: {
                 click: event => {
                   this.$emit('weeknumberclick', {
-                    isoWeek,
-                    days: this.page.days.filter(d => d.isoWeek === isoWeek),
+                    weeknumber,
+                    days: this.page.days.filter(
+                      d => d[this.weeknumberKey] === weeknumber,
+                    ),
                     event,
                   });
                 },
               },
             },
-            [isoWeek],
+            [weeknumber],
           ),
         ],
       );
@@ -95,7 +97,7 @@ export default {
         (showWeeknumbersLeft && mod === 0) ||
         (showWeeknumbersRight && mod === daysInWeek)
       ) {
-        dayCells.push(getWeeknumberCell(day.isoWeek));
+        dayCells.push(getWeeknumberCell(day[this.weeknumberKey]));
       }
       dayCells.push(
         h(CalendarDay, {
@@ -113,7 +115,7 @@ export default {
       );
       // Insert weeknumber cell on right side if needed
       if (showWeeknumbersRight && mod === daysInWeek - 1) {
-        dayCells.push(getWeeknumberCell(day.isoWeek));
+        dayCells.push(getWeeknumberCell(day[this.weeknumberKey]));
       }
     });
 
@@ -154,17 +156,22 @@ export default {
     titlePosition: String,
     navVisibility: String,
     showWeeknumbers: [Boolean, String],
+    showIsoWeeknumbers: [Boolean, String],
   },
   computed: {
+    weeknumberKey() {
+      return this.showWeeknumbers ? 'weeknumber' : 'isoWeeknumber';
+    },
     showWeeknumbers_() {
-      if (this.showWeeknumbers == null) return '';
-      if (isBoolean(this.showWeeknumbers)) {
-        return this.showWeeknumbers ? 'left' : '';
+      const showWeeknumbers = this.showWeeknumbers || this.showIsoWeeknumbers;
+      if (showWeeknumbers == null) return '';
+      if (isBoolean(showWeeknumbers)) {
+        return showWeeknumbers ? 'left' : '';
       }
-      if (this.showWeeknumbers.startsWith('right')) {
-        return this.columnFromEnd > 1 ? 'right' : this.showWeeknumbers;
+      if (showWeeknumbers.startsWith('right')) {
+        return this.columnFromEnd > 1 ? 'right' : showWeeknumbers;
       }
-      return this.column > 1 ? 'left' : this.showWeeknumbers;
+      return this.column > 1 ? 'left' : showWeeknumbers;
     },
     navVisibility_() {
       return this.propOrDefault('navVisibility', 'navVisibility');

--- a/src/components/CalendarPane.vue
+++ b/src/components/CalendarPane.vue
@@ -2,6 +2,7 @@
 import CalendarDay from './CalendarDay';
 import { childMixin, safeScopedSlotMixin } from '../utils/mixins';
 import { getPopoverTriggerEvents } from '../utils/popovers';
+import { isBoolean } from '../utils/_';
 
 export default {
   name: 'CalendarPane',
@@ -141,11 +142,13 @@ export default {
     columnFromEnd: Number,
     titlePosition: String,
     navVisibility: String,
-    showWeeknumbers: String,
+    showWeeknumbers: [Boolean, String],
   },
   computed: {
     showWeeknumbers_() {
       if (this.showWeeknumbers == null) return '';
+      if (isBoolean(this.showWeeknumbers))
+        return this.showWeeknumbers ? 'left' : '';
       if (this.showWeeknumbers.startsWith('right')) {
         return this.columnFromEnd > 1 ? 'right' : this.showWeeknumbers;
       }

--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -12,7 +12,7 @@ import {
   on,
   off,
 } from '../utils/helpers';
-import { isObject, isArray, pick } from '../utils/_';
+import { isObject, isArray } from '../utils/_';
 import {
   showPopover as sp,
   hidePopover as hp,
@@ -218,8 +218,9 @@ export default {
       return /[dD]{1,2}|Do|W{1,4}|M{1,4}|YY(?:YY)?/g.test(this.inputMask);
     },
     inputMaskPatch() {
-      if (this.inputMaskHasTime && this.inputMaskHasDate)
+      if (this.inputMaskHasTime && this.inputMaskHasDate) {
         return PATCH.DATE_TIME;
+      }
       if (this.inputMaskHasDate) return PATCH.DATE;
       if (this.inputMaskHasTime) return PATCH.TIME;
       return undefined;

--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -360,6 +360,7 @@ export default {
         !elementContains(this.$el, e.target)
       ) {
         this.dragValue = null;
+        this.formatInput();
       }
     });
     // Clean up handlers

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -237,7 +237,6 @@
 
   --day-content-transition-time: 0.13s ease-in;
   --weeknumber-offset: -34px;
-  --weeknumber-offset-embedded: -18px;
 
   position: relative;
   display: inline-flex;

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -237,6 +237,7 @@
 
   --day-content-transition-time: 0.13s ease-in;
   --weeknumber-offset: -34px;
+  --weeknumber-offset-embedded: -18px;
 
   position: relative;
   display: inline-flex;

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -236,6 +236,7 @@
   --slide-timing: ease;
 
   --day-content-transition-time: 0.13s ease-in;
+  --weeknumber-offset: -34px;
 
   position: relative;
   display: inline-flex;

--- a/src/utils/locale.js
+++ b/src/utils/locale.js
@@ -427,7 +427,8 @@ export default class Locale {
 
   normalizeDate(d, config = {}) {
     let result = null;
-    let { type, mask, patch, fillDate, time } = config;
+    let { type, fillDate } = config;
+    const { mask, patch, time } = config;
     const auto = type === 'auto' || !type;
     if (isNumber(d)) {
       type = 'number';

--- a/src/utils/locale.js
+++ b/src/utils/locale.js
@@ -672,10 +672,11 @@ export default class Locale {
       const firstWeekday = firstDayOfMonth.getDay() + 1;
       const days = month === 2 && inLeapYear ? 29 : daysInMonths[month - 1];
       const weeks = getWeeksInMonth(firstDayOfMonth, {
-        weekStartsOn: this.firstDayOfWeek - 1
+        weekStartsOn: this.firstDayOfWeek - 1,
       });
-      const isoWeeks = [...Array(weeks).keys()]
-        .map(wIdx => getISOWeek(addDays(firstDayOfMonth, wIdx * 7)));
+      const isoWeeks = [...Array(weeks).keys()].map(wIdx =>
+        getISOWeek(addDays(firstDayOfMonth, wIdx * 7)),
+      );
       comps = {
         firstDayOfWeek: this.firstDayOfWeek,
         inLeapYear,
@@ -684,7 +685,7 @@ export default class Locale {
         weeks,
         month,
         year,
-        isoWeeks
+        isoWeeks,
       };
       this.monthData[key] = comps;
     }
@@ -716,7 +717,7 @@ export default class Locale {
   // Builds day components for a given page
   getCalendarDays({ weeks, monthComps, prevMonthComps, nextMonthComps }) {
     const days = [];
-    const { firstDayOfWeek, firstWeekday } = monthComps;
+    const { firstDayOfWeek, firstWeekday, isoWeeks } = monthComps;
     const prevMonthDaysToShow =
       firstWeekday +
       (firstWeekday < firstDayOfWeek ? daysInWeek : 0) -
@@ -793,6 +794,7 @@ export default class Locale {
         const id = `${pad(year, 4)}-${pad(month, 2)}-${pad(day, 2)}`;
         const weekdayPosition = i;
         const weekdayPositionFromEnd = daysInWeek - i;
+        const isoWeek = isoWeeks[w - 1];
         const isToday =
           day === todayDay && month === todayMonth && year === todayYear;
         const isFirstDay = thisMonth && day === 1;
@@ -814,6 +816,7 @@ export default class Locale {
           weekdayOrdinalFromEnd,
           week,
           weekFromEnd,
+          isoWeek,
           month,
           year,
           dateFromTime,

--- a/src/utils/locale.js
+++ b/src/utils/locale.js
@@ -291,6 +291,7 @@ export default class Locale {
   constructor(config, { locales = defaultLocales, timezone } = {}) {
     const { id, firstDayOfWeek, masks } = resolveConfig(config, locales);
     this.id = id;
+    this.daysInWeek = daysInWeek;
     this.firstDayOfWeek = clamp(firstDayOfWeek, 1, daysInWeek);
     this.masks = masks;
     this.timezone = timezone || undefined;


### PR DESCRIPTION
### Bug Fixes
* Fix `trim-weeks` missing dates if `firstDayOfWeek !== 1`
* Fix input format on calendar hide
* Fix date range normalization for time and input updates

### Improvements

* Add `show-weeknumbers` prop (Boolean | String) with support for `left`, `left-outside`, `right` or `right-outside` positions
* Add `show-iso-weeknumbers` prop (Boolean | String) with support for `left`, `left-outside`, `right` or `right-outside` positions
* Add `weeknumberclick` event that emits week data on click
```js
{
  weeknumber: Number, // Weeknumber clicked (ISO weeknumber if `show-iso-weeknumbers` used)
  days: [Day], // Array of day objects for the weeknumber clicked
  event: MouseEvent, // Native event emitted
}
```

Closes #94.