### PR TITLE
export DatePicker

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,6 +5,8 @@ export default VCalendarLibrary;
 
 export const Calendar: Exclude<Plugin['install'], undefined> | DefineComponent;
 
+export const DatePicker: Exclude<Plugin['install'], undefined> | DefineComponent;
+
 export const Popover: Exclude<Plugin['install'], undefined> | DefineComponent;
 
 export const PopoverRow:


### PR DESCRIPTION
Quick and dirty fix for #827.

Been using v-calendar with Vue 3, fwiw,  does seem stable enough!

Thank you for the library!