### PR TITLE
Extra CSS classes for timepicker

### DIFF
--- a/src/components/DatePicker/DatePicker.vue
+++ b/src/components/DatePicker/DatePicker.vue
@@ -69,7 +69,9 @@ export default {
       const parts = this.isRange ? this.dateParts : [this.dateParts[0]];
       return h(
         'div',
-        {},
+        {
+          class: 'vc-timepicker-container',
+        },
         {
           ...this.$slots,
           default: () =>

--- a/src/components/TimePicker/TimePicker.vue
+++ b/src/components/TimePicker/TimePicker.vue
@@ -3,7 +3,7 @@
     class="vc-time-picker"
     :class="[{ 'vc-invalid': !modelValue.isValid, 'vc-bordered': showBorder }]"
   >
-    <div>
+    <div class="vc-time-icon-container">
       <svg
         fill="none"
         stroke-linecap="round"


### PR DESCRIPTION
Add some extra CSS classes for timepicker for flexible styling.


## Example for range selector
```css
.vc-timepicker-container{
    @apply flex;
    background-image: url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' class='w-4 h-4 mx-2' fill='none' viewBox='0 0 24 24' style='stroke: rgb(160, 174, 192);' %3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M14 5l7 7m0 0l-7 7m7-7H3' /%3E%3C/svg%3E");
    background-position: 51% 70%;
    background-size: 0.75rem 0.75rem;
    background-repeat: no-repeat;
    .vc-time-icon-container{
        display: none;
    }
    .vc-time-date{
        span{
            @apply text-xxs;
        }
    }
}
```

## Result
<img width="292" alt="Screenshot-2021-04-22-at-12 53 30" src="https://user-images.githubusercontent.com/2779993/115694713-ce1f8d80-a369-11eb-85a4-9ba8c7f636be.png">
