### PR TITLE
[docs] Fix broken link for popover.placement prop

### DIFF
--- a/docs/api/v2.0/datepicker.md
+++ b/docs/api/v2.0/datepicker.md
@@ -130,7 +130,7 @@ Setting `value = null` still allowed through code.
 
 **Type:** String
 
-**Description:** Default or suggested placement of the popover. This may change as the browser window dimensions change. [Valid placements](https://popper.js.org/popper-documentation.html#Popper.placements) include `auto`, `top`, `right`, `bottom`, `left`. Each placement can have suffixed variations `-start` or `-end`.
+**Description:** Default or suggested placement of the popover. This may change as the browser window dimensions change. [Valid placements](https://popper.js.org/docs/v2/constructors/#options) include `auto`, `top`, `right`, `bottom`, `left`. Each placement can have suffixed variations `-start` or `-end`.
 
 **Default:** `bottom-start`
 


### PR DESCRIPTION
Noticed the link to the "Valid placements" page was broken.

Source: https://vcalendar.io/api/v2.0/datepicker.html#popover-placement