### PR TITLE
Updated date picker to watch value in range mode.

### DIFF
--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -330,14 +330,17 @@ export default {
     inputMask() {
       this.formatInput();
     },
-    value() {
-      if (!this.watchValue) return;
-      this.forceUpdateValue(this.value, {
-        config: this.modelConfig_,
-        notify: false,
-        formatInput: true,
-        hidePopover: false,
-      });
+    value: {
+      handler() {
+        if (!this.watchValue) return;
+        this.forceUpdateValue(this.value, {
+          config: this.modelConfig_,
+          notify: false,
+          formatInput: true,
+          hidePopover: false,
+        });
+      },
+      deep: true
     },
     value_() {
       this.refreshDateParts();


### PR DESCRIPTION
**v-calendar** 2.3.0
**vue** 2.6.11
**browser** Version 91.0.4472.101 (Official Build) (x86_64)
**Description**
When using the date picker in range mode the range isn't reactive when set externally. I need to be able to set the date from an external source and have the date picker use the new dates. This works when using a single date but not when isRange is true.
I've created a code sandbox to show how to reproduce the issue.

https://codesandbox.io/s/v-calendar-range-reactive-issue-fqj8j?file=/src/components/DatePicker.vue

**Fix**
Update the watch on value prop to be deep to for when the value is an object.



