### PR TITLE
Added two additional properties in scoped slot (#day-content)

### DIFF
--- a/src/components/CalendarDay.vue
+++ b/src/components/CalendarDay.vue
@@ -39,6 +39,8 @@ export default {
         day: this.day,
         attributes: this.day.attributes,
         attributesMap: this.day.attributesMap,
+        dayClass: this.dayContentClass,
+        dayStyle: this.dayContentStyle,
         dayProps: this.dayContentProps,
         dayEvents: this.dayContentEvents,
       }) ||


### PR DESCRIPTION
Hi! 😀 Thanks for your work!

This PR will set two additional properties in scoped slot (#day-content):
- **dayClass** – contains the classes needed for the button day
- **dayStyle** – contains the styles needed for the day of the button

Use example:
```
<template #day-content="{ day, dayEvents, dayProps, dayClass, dayStyle }">
  <span :class="dayClass" :style="dayStyle" v-bind="dayProps" v-on="dayEvents">
    <span>{{day.label}}</span>
    <small v-if="!day.isDisabled">10 $</small>
  </span>
</template>
```

Thanks! 