### PR TITLE
Add onRejected arrow function

### DIFF
--- a/src/components/Calendar/Calendar.vue
+++ b/src/components/Calendar/Calendar.vue
@@ -797,7 +797,7 @@ export default {
       }
       if (newDate) {
         event.preventDefault();
-        this.focusDate(newDate).catch();
+        this.focusDate(newDate).catch(() => {});
       }
     },
   },


### PR DESCRIPTION
Currently error populates from move method to console for end user to see (i.e. in scenario where user is on last month day and next month is disabled using keyboard):
```
Uncaught (in promise) Error: Move target is disabled: ...
```

This change passed empty arrow function that swallows this error.

Note: same behavior exist in v2.
