### PR TITLE
Closing slash of DatePicker component for Method 3: Use Components As Needed

### DIFF
--- a/docs/vue-3.md
+++ b/docs/vue-3.md
@@ -69,7 +69,7 @@ createApp(App)
 ```html
 <template>
   <Calendar />
-  <DatePicker v-model="date">
+  <DatePicker v-model="date" />
 </template>
 ```
 


### PR DESCRIPTION
  <DatePicker v-model="date" /> instead  of  <DatePicker v-model="date">
There should be a closing slash on DatePicker Component in Method 3: Use Components As Needed