### PR TITLE
fix error binding v-model when using TimeSelect

### DIFF
--- a/src/components/TimeSelect.vue
+++ b/src/components/TimeSelect.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="vc-select">
-    <select v-bind="$attrs" @change="$emit('input', $event.target.value)">
+    <select v-model="model" v-bind="$attrs" @change="$emit('input', $event.target.value)">
       <option
         v-for="option in options"
         :key="option.value"
@@ -24,7 +24,18 @@ export default {
   inheritAttrs: false,
   props: {
     options: Array,
+    value: Number
   },
+  computed: {
+    model: {
+      get() {
+        return this.value;
+      },
+      set(value) {
+        this.$emit('input', value);
+      }
+    }
+  }
 };
 </script>
 


### PR DESCRIPTION
Hey guy I am have an issue when using DatePicker with mode `time`, `dateTime` and has `minute-increment` prop.
For example: 
``` vue
<template>
  <DatePicker v-model="model" mode="dateTime" :minute-increment="5" :popover="{visibility: 'focus'}">
    <template v-slot="{ inputValue, inputEvents, togglePopover}">
      <slot v-bind="{inputValue, inputEvents, togglePopover}">
        <input :value="inputValue" v-on="inputEvents">
      </slot>
    </template>
  </DatePicker>
</template>
<script>
export default {
  data() {
    return {
      model: new Date()
    }
  }
}
</script>
```
When I change input value from `09/28/2021 6:05 PM` to `09/28/2021 6:42 PM`. The select of minute had be set to `00`. That wrong

So this pull request I just define & handle v-model in component TimeSelect to resolve this issue.