### PR TITLE
chore(docs): Fix typo in documentation

### DIFF
--- a/docs/api/v2.0/datepicker.md
+++ b/docs/api/v2.0/datepicker.md
@@ -16,7 +16,7 @@ sidebarDepth: 2
 
 **Description:** Selection mode: `"date"`, `"dateTime"`, `"time"`
 
-**Default:** `"single"`
+**Default:** `"date"`
 
 ### `value`
 


### PR DESCRIPTION
Default value for `mode` is `date`
https://github.com/nathanreyes/v-calendar/blob/a4e9bceb168aa302eeff5143d41d057c1c5ee547/src/components/DatePicker.vue#L155