### PR TITLE
fix(attributes.md): Remove duplicate </template>

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -652,7 +652,7 @@ Finally, if you wish to display indicators with your custom content, you can use
         :attribute="attr">
         {{ attr.customData.description }}
       </popover-row>
-    </template>
+    </div>
   </template>
 </v-calendar>
 ```


### PR DESCRIPTION
This example contains two closing `</template>` tags (first one should be a `</div>`) which leads to issues when copy pasting.