### PR TITLE
Add compatConfig option to all components

### DIFF
--- a/src/components/Calendar/Calendar.vue
+++ b/src/components/Calendar/Calendar.vue
@@ -37,6 +37,7 @@ import {
 
 export default {
   name: 'Calendar',
+  compatConfig: { MODE: 3 },
   emits: [
     'dayfocusin',
     'dayfocusout',

--- a/src/components/CalendarDay/CalendarDay.vue
+++ b/src/components/CalendarDay/CalendarDay.vue
@@ -7,6 +7,7 @@ import { last, get, defaults } from '../../utils/_';
 
 export default {
   name: 'CalendarDay',
+  compatConfig: { MODE: 3 },
   emits: [
     'dayclick',
     'daymouseenter',

--- a/src/components/CalendarNav/CalendarNav.vue
+++ b/src/components/CalendarNav/CalendarNav.vue
@@ -70,6 +70,7 @@ const _yearGroupCount = 12;
 
 export default {
   name: 'CalendarNav',
+  compatConfig: { MODE: 3 },
   emits: ['input'],
   components: {
     SvgIcon,

--- a/src/components/CalendarPane/CalendarPane.vue
+++ b/src/components/CalendarPane/CalendarPane.vue
@@ -8,6 +8,7 @@ import { isBoolean } from '../../utils/_';
 
 export default {
   name: 'CalendarPane',
+  compatConfig: { MODE: 3 },
   emits: ['update:page', 'weeknumberclick'],
   mixins: [childMixin, slotMixin],
   inheritAttrs: false,

--- a/src/components/CustomTransition/CustomTransition.vue
+++ b/src/components/CustomTransition/CustomTransition.vue
@@ -11,6 +11,7 @@
 <script>
 export default {
   name: 'CustomTransition',
+  compatConfig: { MODE: 3 },
   emits: [
     'before-enter',
     'before-transition',

--- a/src/components/DatePicker/DatePicker.vue
+++ b/src/components/DatePicker/DatePicker.vue
@@ -44,6 +44,7 @@ const RANGE_PRIORITY = {
 
 export default {
   name: 'DatePicker',
+  compatConfig: { MODE: 3 },
   emits: [
     'update:modelValue',
     'drag',

--- a/src/components/Popover/Popover.vue
+++ b/src/components/Popover/Popover.vue
@@ -7,6 +7,7 @@ import CustomTransition from '../CustomTransition/CustomTransition.vue';
 
 export default {
   name: 'Popover',
+  compatConfig: { MODE: 3 },
   emits: ['before-show', 'after-show', 'before-hide', 'after-hide'],
   render() {
     return h(

--- a/src/components/PopoverRow/PopoverRow.vue
+++ b/src/components/PopoverRow/PopoverRow.vue
@@ -19,6 +19,7 @@ import { childMixin } from '../../utils/mixins';
 
 export default {
   name: 'PopoverRow',
+  compatConfig: { MODE: 3 },
   mixins: [childMixin],
   props: {
     attribute: Object,

--- a/src/components/SvgIcon/SvgIcon.vue
+++ b/src/components/SvgIcon/SvgIcon.vue
@@ -21,6 +21,7 @@ const icons = {
 
 export default {
   props: ['name'],
+  compatConfig: { MODE: 3 },
   data() {
     return {
       width: _defSize,

--- a/src/components/TimePicker/TimePicker.vue
+++ b/src/components/TimePicker/TimePicker.vue
@@ -91,6 +91,7 @@ const _pmOptions = [
 
 export default {
   name: 'TimePicker',
+  compatConfig: { MODE: 3 },
   components: { TimeSelect },
   emits: ['update:modelValue'],
   props: {

--- a/src/components/TimeSelect/TimeSelect.vue
+++ b/src/components/TimeSelect/TimeSelect.vue
@@ -26,6 +26,7 @@
 
 <script>
 export default {
+  compatConfig: { MODE: 3 },
   inheritAttrs: false,
   emits: ['update:modelValue'],
   props: {


### PR DESCRIPTION
As explained in this [closed issue ](https://github.com/nathanreyes/v-calendar/issues/1049), Vue3 `v-calendar` components are not working when using [@vue/compat](https://github.com/vuejs/core/tree/main/packages/vue-compat).

This PR adds `compatConfig: { MODE: 3 }` to all components to make them work in `vue-compat` mode.

This option will be simply ignored when the client app is not using `vue-compat` mode.


