### PR TITLE
fixed if(timezone) logic not replacing tzDate in dates:getDateParts

### DIFF
--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -530,11 +530,9 @@ export function getDateParts(
   firstDayOfWeek: DayOfWeek,
   timezone = '',
 ): DateParts {
-  const tzDate = date;
+  let tzDate = date;
   if (timezone) {
-    const tzDate = new Date(
-      date.toLocaleString('en-US', { timeZone: timezone }),
-    );
+    tzDate = new Date(date.toLocaleString('en-US', { timeZone: timezone }));
     tzDate.setMilliseconds(date.getMilliseconds());
   }
   const milliseconds = tzDate.getMilliseconds();


### PR DESCRIPTION
In looking into setting up the `vitest` tests in #1176, I found one of the tests breaking due to this bug. Applying this patch on the vitest branch shows the test now passes :) 