### PR TITLE
a11y patch for vc-title

### DIFF
--- a/src/components/CalendarPane/CalendarPane.vue
+++ b/src/components/CalendarPane/CalendarPane.vue
@@ -22,6 +22,7 @@ export default {
           'div',
           {
             class: 'vc-title',
+            role: 'button',
             ...this.navPopoverEvents,
           },
           [this.safeSlot('header-title', this.page, this.page.title)],


### PR DESCRIPTION
In use process, I notice that the Header without specify for the button role, In fact, its role should be a button. what do you think?