### PR TITLE
DatePicker allows users to specify `valid-minutes`

### DIFF
--- a/src/components/DatePicker/DatePicker.vue
+++ b/src/components/DatePicker/DatePicker.vue
@@ -78,6 +78,7 @@ export default {
                 dp,
               );
               const minuteOptions = this.$locale.getMinuteOptions(
+                this.modelConfig_[idx].validMinutes,
                 this.modelConfig_[idx].minuteIncrement,
                 dp,
               );
@@ -185,6 +186,7 @@ export default {
     selectAttribute: Object,
     attributes: Array,
     validHours: [Object, Array, Function],
+    validMinutes: [Object, Array, Function],
   },
   data() {
     return {
@@ -561,6 +563,7 @@ export default {
         : [config.start || config, config.end || config];
       return baseConfig.map((b, i) => ({
         validHours: this.validHours,
+        validMinutes: this.validMinutes,
         minuteIncrement: this.minuteIncrement,
         ...b,
         ...config[i],

--- a/src/utils/locale.js
+++ b/src/utils/locale.js
@@ -523,7 +523,18 @@ export default class Locale {
     );
   }
 
-  getMinuteOptions(minuteIncrement) {
+  minuteIsValid(minute, validMinutes, dateParts) {
+    if (!validMinutes) return true;
+    if (isArray(validMinutes)) return validMinutes.includes(minute);
+    if (isObject(validMinutes)) {
+      const min = validMinutes.min || 0;
+      const max = validMinutes.max || 59;
+      return min <= minute && max >= minute;
+    }
+    return validMinutes(minute, dateParts);
+  }
+
+  getMinuteOptions(validMinutes, minuteIncrement, dateParts) {
     const options = [];
     minuteIncrement = minuteIncrement > 0 ? minuteIncrement : 1;
     for (let i = 0; i <= 59; i += minuteIncrement) {
@@ -532,7 +543,9 @@ export default class Locale {
         label: pad(i, 2),
       });
     }
-    return options;
+    return options.filter(opt =>
+      this.minuteIsValid(opt.value, validMinutes, dateParts),
+    );
   }
 
   nearestOptionValue(value, options) {

--- a/tests/unit/specs/DatePicker.spec.js
+++ b/tests/unit/specs/DatePicker.spec.js
@@ -177,6 +177,25 @@ describe('DatePicker', () => {
     //   const hours = [8, 9, 10, 11, 12];
     //   checkValidHours(prop, hours);
     // });
+
+
+    it(':valid-minutes - limits minutes to array', async () => {
+      const minutes = [0, 3, 5, 8, 10, 11, 15, 19, 23];
+      checkValidMinutes(minutes, minutes);
+    });
+
+    it(':valid-minutes - limits minutes to min/max', async () => {
+      const prop = { min: 4, max: 15 };
+      const minutes = [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+      checkValidMinutes(prop, minutes);
+    });
+
+    it(':valid-minutes - limits minutes to function', async () => {
+      const prop = (minute, { weekday }) =>
+        ![1, 7].includes(weekday) || (minute >= 0 && minute <= 5);
+      const minutes = [0, 1, 2, 3, 4, 5];
+      checkValidMinutes(prop, minutes);
+    });
   });
 });
 
@@ -196,6 +215,25 @@ async function checkValidHours(prop, hours) {
   expect(options.length).toEqual(hours.length);
   hours.forEach((hour, i) => {
     expect(options[i].value).toEqual(hour.toString());
+  });
+}
+
+async function checkValidMinutes(prop, minutes) {
+  const dp = mount(DatePicker, {
+    props: {
+      modelValue: new Date(2000, 0, 15),
+      mode: 'dateTime',
+      is24hr: true,
+      validMinutes: prop,
+    },
+  });
+  await dp.vm.$nextTick();
+  await dp.vm.$nextTick();
+  const selector = dp.find('.vc-select:nth-of-type(2) select');
+  const options = selector.element.options;
+  expect(options.length).toEqual(minutes.length);
+  minutes.forEach((minute, i) => {
+    expect(options[i].value).toEqual(minute.toString());
   });
 }
 


### PR DESCRIPTION
Hello!

💁 This PR implements a new `:valid-minutes` prop that can be used to limit the available minutes for selection.

Related: https://github.com/nathanreyes/v-calendar/issues/1128

This feature functions almost identically to the `:valid-hours` prop. Users can provide either:

  - An array of valid minutes (e.g. `<DatePicker :valid-minutes="[0, 15, 30, 45]" />`)
  - An object that specifies a range of valid minutes (e.g. `<DatePicker :valid-minutes="{ min: 0, max: 30 }" />`)
  - A function that returns an array of valid minutes (e.g. `<DatePicker :valid-minutes="hour => hour % 2 === 1" />`)

I have included tests for this new feature, although I had issues getting the tests to run on `next` without any modifications. I'm happy to work through this, but will likely need some help getting other tests to pass. 