### PR TITLE
Fix the current year selection in December

### DIFF
--- a/src/components/CalendarNav.vue
+++ b/src/components/CalendarNav.vue
@@ -208,7 +208,7 @@ export default {
       const items = [];
       for (let year = startYear; year < endYear; year += 1) {
         let enabled = false;
-        for (let month = 1; month < 12; month++) {
+        for (let month = 1; month <= 12; month++) {
           enabled = this.validator({ month, year });
           if (enabled) break;
         }


### PR DESCRIPTION
This fixes an issue where the current year could not be selected when using December as `min-date`.

Fixes https://github.com/nathanreyes/v-calendar/issues/1131