### PR TITLE
Bug with DatePicker when inputting date range

### DIFF
--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -635,13 +635,13 @@ export default {
       if (!this.hasValue(value)) return null;
       if (this.isRange) {
         const result = {};
-        const start = value.start > value.end ? value.end : value.start;
+        const start = Date(value.start) > Date(value.end) ? value.end : value.start;
         result.start = this.normalizeDate(start, {
           ...config[0],
           fillDate: (this.value_ && this.value_.start) || config[0].fillDate,
           patch,
         });
-        const end = value.start > value.end ? value.start : value.end;
+        const end = Date(value.start) > Date(value.end) ? value.start : value.end;
         result.end = this.normalizeDate(end, {
           ...config[1],
           fillDate: (this.value_ && this.value_.end) || config[1].fillDate,

--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -635,18 +635,19 @@ export default {
       if (!this.hasValue(value)) return null;
       if (this.isRange) {
         const result = {};
-        const start = Date(value.start) > Date(value.end) ? value.end : value.start;
+        const start = new Date(value.start).getTime() > new Date(value.end).getTime() ? value.end : value.start;
         result.start = this.normalizeDate(start, {
           ...config[0],
           fillDate: (this.value_ && this.value_.start) || config[0].fillDate,
           patch,
         });
-        const end = Date(value.start) > Date(value.end) ? value.start : value.end;
+        const end = new Date(value.start).getTime() > new Date(value.end).getTime() > 0 ? value.start : value.end;
         result.end = this.normalizeDate(end, {
           ...config[1],
           fillDate: (this.value_ && this.value_.end) || config[1].fillDate,
           patch,
         });
+        console.log(start, end, result);
         return this.sortRange(result, rangePriority);
       }
       return this.normalizeDate(value, {

--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -647,7 +647,6 @@ export default {
           fillDate: (this.value_ && this.value_.end) || config[1].fillDate,
           patch,
         });
-        console.log(start, end, result);
         return this.sortRange(result, rangePriority);
       }
       return this.normalizeDate(value, {

--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -641,7 +641,7 @@ export default {
           fillDate: (this.value_ && this.value_.start) || config[0].fillDate,
           patch,
         });
-        const end = new Date(value.start).getTime() > new Date(value.end).getTime() > 0 ? value.start : value.end;
+        const end = new Date(value.start).getTime() > new Date(value.end).getTime() ? value.start : value.end;
         result.end = this.normalizeDate(end, {
           ...config[1],
           fillDate: (this.value_ && this.value_.end) || config[1].fillDate,


### PR DESCRIPTION
While using input elements to update the Date Picker a user can encounter a bug where a valid date range can be rejected and set to a singular day equal to the end date. 

When entering a start date with a year less than that of the end date and a MM/dd later in the year than the end date, the input is treated as if it is greater than the end date. See the first video for examples using the v-calendar guide. The bug occurs when 10/17/2019 and 10/18/2019 are entered.

This is caused by the comparison of the dates as strings rather than as date objects. The second video shows the implemented fix has solved the problem.


https://user-images.githubusercontent.com/87655487/210299242-b48195af-1800-4482-b9e3-1ba81a021c16.mov

https://user-images.githubusercontent.com/87655487/210299255-f6173bd2-6c16-4e46-98c8-3138f1897f00.mov

