### PR TITLE
datePicker.ts update for dateTime mode

### DIFF
--- a/src/use/datePicker.ts
+++ b/src/use/datePicker.ts
@@ -643,7 +643,7 @@ export function createDatePicker(
     const opts: Partial<UpdateOptions> = {
       patch: 'date',
       formatInput: true,
-      hidePopover: true,
+      hidePopover: !isDateTimeMode.value,
     };
     if (isRange.value) {
       const dragging = !isDragging.value;


### PR DESCRIPTION
If we have "dateTime" mode and select a date, the popover is closed, and need to reopen the popover to select the time. When we use "dateTime" mode we want to select Date + Time. Please merge this as hotfix.