### PR TITLE
Update attributes dates weekday repeater example

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -439,7 +439,12 @@ export default {
       {
         description: 'Take Noah to basketball practice.',
         isComplete: false,
-        dates: { weekdays: 6 }, // Every Friday
+        dates: {
+          repeat: {
+            from: null,
+            weekdays: 6 // Every Friday
+          }
+        },
         color: 'red',
       },
     ];


### PR DESCRIPTION
The provided example didn't work, it would behave like `dates` was an empty object, selecting all days.