### PR TITLE
fix: Spread disabled dates before modifying them

### DIFF
--- a/src/use/base.ts
+++ b/src/use/base.ts
@@ -67,7 +67,7 @@ export function createBase(props: BaseProps) {
   const masks = computed(() => locale.value.masks);
 
   const disabledDates = computed(() => {
-    const dates: any[] = props.disabledDates ?? [];
+    const dates: any[] = [...props.disabledDates] ?? [];
     // Add disabled range for min date
     if (props.minDate != null) {
       dates.push({


### PR DESCRIPTION
Modifying the array passed as a prop can create bugs, that are hard to debug. For example changing `minDate` will change disabledDates. Especially if the value passed to the prop is computed, it is very hard to spot the problem.