### PR TITLE
fix: Allow attribute properties to be optional

### DIFF
--- a/src/utils/attribute.ts
+++ b/src/utils/attribute.ts
@@ -30,7 +30,7 @@ export type EventConfig = Partial<{
   label: string;
 }>;
 
-export interface AttributeConfig {
+export type AttributeConfig = Partial<{
   key: string | number;
   hashcode: string;
   content: ContentConfig;
@@ -43,7 +43,7 @@ export interface AttributeConfig {
   customData: any;
   order: number;
   pinPage: boolean;
-}
+}>;
 
 export class Attribute {
   key: string | number = '';


### PR DESCRIPTION
When passing `:select-attribute` or `:drag-attribute` properties, TypeScript complains about missing properties.

Example [from the docs](https://vcalendar.io/datepicker/custom-attributes.html#select-attribute):
```
<template>
  <VDatePicker v-model="date" :select-attribute="selectAttribute" />
</template>

<script setup>
import { ref } from 'vue';

const date = ref(new Date());
const selectAttribute = ref({ dot: true });
</script>
```

TypeScript complains about missing properties:

`Type '{ dot: boolean; }' is missing the following properties from type 'AttributeConfig': key, hashcode, content, highlight, and 7 more.`

This PR makes all `AttributeConfig` properties optional (by using TS's `Partial<>` utility type) and fixes the above type error.