### PR TITLE
Bug with DatePicker when inputting date range - fix for v2

### DIFF
--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -635,13 +635,13 @@ export default {
       if (!this.hasValue(value)) return null;
       if (this.isRange) {
         const result = {};
-        const start = value.start > value.end ? value.end : value.start;
+        const start = new Date(value.start).getTime() > new Date(value.end).getTime() ? value.end : value.start;
         result.start = this.normalizeDate(start, {
           ...config[0],
           fillDate: (this.value_ && this.value_.start) || config[0].fillDate,
           patch,
         });
-        const end = value.start > value.end ? value.start : value.end;
+        const end = new Date(value.start).getTime() > new Date(value.end).getTime() ? value.start : value.end;
         result.end = this.normalizeDate(end, {
           ...config[1],
           fillDate: (this.value_ && this.value_.end) || config[1].fillDate,


### PR DESCRIPTION
The fix addresses the issue of not being able to select a date range spanning two months when using keyboard input. The problem has already been resolved for v3 in this [MR](https://github.com/nathanreyes/v-calendar/pull/1236), and this is the same fix being applied to v2.

I would greatly appreciate it if you could merge this and create a release for v2, benefiting Vue2 users. 🙏 Thanks in advance!