### PR TITLE
Map through content classes instead of picking the last one

### DIFF
--- a/src/components/CalendarDay.vue
+++ b/src/components/CalendarDay.vue
@@ -2,7 +2,7 @@
 import { childMixin, safeScopedSlotMixin } from '../utils/mixins';
 import { arrayHasItems, mergeEvents } from '../utils/helpers';
 import { getPopoverTriggerEvents, updatePopover } from '../utils/popovers';
-import { last, get, defaults } from '../utils/_';
+import { last, get, map, defaults } from '../utils/_';
 
 export default {
   name: 'CalendarDay',
@@ -175,7 +175,7 @@ export default {
       return [
         'vc-day-content vc-focusable',
         { 'is-disabled': this.isDisabled },
-        get(last(this.content), 'class') || '',
+        ...map(this.content, 'class'),
       ];
     },
     dayContentStyle() {


### PR DESCRIPTION
Potential solution to https://github.com/nathanreyes/v-calendar/issues/1428

Instead of grabbing classes from the last object in the content array, map over them. Allows you to apply attributes to days that have internal `content` added instead of the internal values overriding the attributes we define.  

I couldn't find existing test coverage for this area, but happy to add if I missed it.