### PR TITLE
Updated Type of the DatePartsRuleFunction v3

### DIFF
--- a/src/utils/date/helpers.ts
+++ b/src/utils/date/helpers.ts
@@ -142,7 +142,7 @@ interface NumberRuleConfig {
   interval?: number;
 }
 
-type DatePartsRuleFunction = (part: number, parts: TimeParts) => boolean;
+type DatePartsRuleFunction = (part: number, parts: DateParts) => boolean;
 
 type DatePartsRule =
   | number


### PR DESCRIPTION
The type of the `DatePartsRuleFunction` is incorrect, according to the implementation it looks like we pass `DateParts` instead of `TimeParts`, and it's confirmed in runtime.
![image](https://github.com/nathanreyes/v-calendar/assets/44264841/ff1e4c1c-d0f9-4970-b7d1-87438da20762)

So replaced with correct type
