### PR TITLE
Fix: "Space" or "Enter" key on header nav arrows results in movePrev/moveNext firing twice

### DIFF
--- a/src/components/Calendar/CalendarHeader.vue
+++ b/src/components/Calendar/CalendarHeader.vue
@@ -10,7 +10,6 @@
       class="vc-arrow vc-prev vc-focus"
       :disabled="!canMovePrev"
       @click="movePrev"
-      @keydown.space.enter="movePrev"
     >
       <CalendarSlot name="header-prev-button" :disabled="!canMovePrev">
         <BaseIcon name="ChevronLeft" size="24" />
@@ -31,7 +30,6 @@
       class="vc-arrow vc-next vc-focus"
       :disabled="!canMoveNext"
       @click="moveNext"
-      @keydown.space.enter="moveNext"
     >
       <CalendarSlot name="header-next-button" :disabled="!canMoveNext">
         <BaseIcon name="ChevronRight" size="24" />


### PR DESCRIPTION
Fix for #1459 

This is to remove `keydown` listeners on the `CalendarHeader` prev/next arrow buttons, as they appear to cause `movePrev / moveNext` to fire twice – once in the keydown handler, and then again in the click handler.  