### PR TITLE
Fix missing closing tag

### DIFF
--- a/docs/vue-3.md
+++ b/docs/vue-3.md
@@ -78,7 +78,7 @@ app.use(SetupCalendar, {})
 <!-- Component.vue template -->
 <template>
   <Calendar />
-  <DatePicker v-model="date">
+  <DatePicker v-model="date" />
 </template>
 ```
 


### PR DESCRIPTION
The other methods (Method 1 and 2) have a slash (/) before the close angle bracket.

Thank you for your consideration!